### PR TITLE
improve balances table

### DIFF
--- a/@types/types.tsx
+++ b/@types/types.tsx
@@ -47,6 +47,7 @@ export interface Balances extends BalancesBase {
   deposits?: I80F48 | null | undefined
   borrows?: I80F48 | null | undefined
   net?: I80F48 | null | undefined
+  value?: I80F48 | null | undefined
 }
 
 export interface OpenOrdersBalances extends BalancesBase {

--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -1,23 +1,42 @@
 import { useBalances } from '../hooks/useBalances'
 import useMangoStore, { mangoClient } from '../stores/useMangoStore'
-import Button from '../components/Button'
+import Button, { LinkButton } from '../components/Button'
 import { notify } from '../utils/notifications'
-import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
-import { InformationCircleIcon } from '@heroicons/react/outline'
-import Tooltip from './Tooltip'
+import { ArrowSmDownIcon, ExclamationIcon } from '@heroicons/react/outline'
+import { ChevronDownIcon } from '@heroicons/react/solid'
 import { Market } from '@project-serum/serum'
-import { ZERO_I80F48 } from '@blockworks-foundation/mango-client'
+import { getTokenBySymbol } from '@blockworks-foundation/mango-client'
 import { useState } from 'react'
 import Loading from './Loading'
+import { useViewport } from '../hooks/useViewport'
+import { breakpoints } from './TradePageGrid'
+import { Disclosure } from '@headlessui/react'
+import { floorToDecimal, formatUsdValue } from '../utils'
+import { Table, Td, Th, TrBody, TrHead } from './TableElements'
+import { useSortableData } from '../hooks/useSortableData'
 
 const BalancesTable = () => {
   const balances = useBalances()
+  const { items, requestSort, sortConfig } = useSortableData(
+    balances
+      .filter(
+        (bal) =>
+          +bal.deposits > 0 ||
+          +bal.borrows > 0 ||
+          bal.orders > 0 ||
+          bal.unsettled > 0
+      )
+      .sort((a, b) => Math.abs(+b.value) - Math.abs(+a.value))
+  )
   const actions = useMangoStore((s) => s.actions)
+  const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
+  const mangoGroupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
+  const { width } = useViewport()
   const [submitting, setSubmitting] = useState(false)
+  const isMobile = width < breakpoints.sm
 
   async function handleSettleAll() {
     const mangoAccount = useMangoStore.getState().selectedMangoAccount.current
-    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
     const markets = useMangoStore.getState().selectedMangoGroup.markets
     const wallet = useMangoStore.getState().wallet.current
 
@@ -50,101 +69,182 @@ const BalancesTable = () => {
     }
   }
 
-  const filteredBalances = balances.filter(
-    (bal) =>
-      +bal.deposits > 0 ||
-      +bal.borrows > 0 ||
-      bal.orders > 0 ||
-      bal.unsettled > 0
-  )
+  const unsettledBalances = balances.filter((bal) => bal.unsettled > 0)
 
   return (
     <div className={`flex flex-col py-4`}>
+      {unsettledBalances.length > 0 ? (
+        <div className="border border-th-bkg-4 rounded-lg mb-6 p-6">
+          <div className="flex items-center justify-between pb-4">
+            <div className="flex items-center text-lg">
+              <ExclamationIcon className="flex-shrink-0 h-5 mr-1.5 mt-0.5 text-th-primary w-5" />
+              Unsettled Balances
+            </div>
+            <Button
+              className="text-xs pt-0 pb-0 h-8 pl-3 pr-3 whitespace-nowrap"
+              onClick={handleSettleAll}
+            >
+              {submitting ? <Loading /> : 'Settle All'}
+            </Button>
+          </div>
+          {unsettledBalances.map((bal) => {
+            const tokenConfig = getTokenBySymbol(mangoGroupConfig, bal.symbol)
+            return (
+              <div
+                className="border-b border-th-bkg-4 flex items-center justify-between py-4 last:border-b-0 last:pb-0"
+                key={bal.symbol}
+              >
+                <div className="flex items-center">
+                  <img
+                    alt=""
+                    width="20"
+                    height="20"
+                    src={`/assets/icons/${bal.symbol.toLowerCase()}.svg`}
+                    className={`mr-2.5`}
+                  />
+                  <div>{bal.symbol}</div>
+                </div>
+                {`${floorToDecimal(bal.unsettled, tokenConfig.decimals)} ${
+                  bal.symbol
+                }`}
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
       <div className={`-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8`}>
         <div className={`align-middle inline-block min-w-full sm:px-6 lg:px-8`}>
-          {balances.length > 0 &&
-          (balances.find(({ unsettled }) => unsettled > 0) ||
-            balances.find(
-              ({ borrows, deposits }) =>
-                borrows.gt(ZERO_I80F48) && deposits.gt(ZERO_I80F48)
-            )) ? (
-            <div
-              className={`flex items-center justify-between px-6 py-3 mb-2 rounded-md bg-th-bkg-1`}
-            >
-              <div className="flex items-center text-fgd-1 font-semibold pr-4">
-                You have unsettled funds
-                <Tooltip content="Use the Settle All button to move unsettled funds to your deposits. If you have borrows, settling will use deposits for that asset to reduce your borrows.">
-                  <div>
-                    <InformationCircleIcon
-                      className={`h-5 w-5 ml-2 text-th-primary cursor-help`}
-                    />
-                  </div>
-                </Tooltip>
-              </div>
-              {submitting ? (
-                <Loading className="-ml-1 mr-3" />
-              ) : (
-                <Button onClick={handleSettleAll}>Settle All</Button>
-              )}
-            </div>
-          ) : null}
-          {filteredBalances.length > 0 ? (
-            <div
-              className={`overflow-hidden border-b border-th-bkg-2 sm:rounded-md`}
-            >
-              <Table className={`min-w-full divide-y divide-th-bkg-2`}>
-                <Thead>
-                  <Tr className="text-th-fgd-3 text-xs">
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      Asset
-                    </Th>
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      Deposits
-                    </Th>
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      Borrows
-                    </Th>
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      In Orders
-                    </Th>
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      Unsettled
-                    </Th>
-                    <Th
-                      scope="col"
-                      className={`px-6 py-2 text-left font-normal`}
-                    >
-                      Net
-                    </Th>
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {filteredBalances.map((balance, index) => {
-                    return (
-                      <Tr
-                        key={`${index}`}
-                        className={`border-b border-th-bkg-3
-                        ${index % 2 === 0 ? `bg-th-bkg-3` : `bg-th-bkg-2`}
-                      `}
+          {items.length > 0 ? (
+            !isMobile ? (
+              <Table>
+                <thead>
+                  <TrHead>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('symbol')}
                       >
-                        <Td
-                          className={`flex items-center px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
+                        Asset
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'symbol'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('deposits')}
+                      >
+                        Deposits
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'deposits'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('borrows')}
+                      >
+                        Borrows
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'borrows'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('orders')}
+                      >
+                        In Orders
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'orders'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('unsettled')}
+                      >
+                        Unsettled
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'unsettled'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('net')}
+                      >
+                        Net Balance
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'net'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                    <Th>
+                      <LinkButton
+                        className="flex items-center no-underline font-normal text-left"
+                        onClick={() => requestSort('value')}
+                      >
+                        Value
+                        <ArrowSmDownIcon
+                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
+                            sortConfig?.key === 'value'
+                              ? sortConfig.direction === 'ascending'
+                                ? 'transform rotate-180'
+                                : 'transform rotate-360'
+                              : null
+                          }`}
+                        />
+                      </LinkButton>
+                    </Th>
+                  </TrHead>
+                </thead>
+                <tbody>
+                  {items.map((balance, index) => (
+                    <TrBody index={index} key={`${balance.symbol}${index}`}>
+                      <Td>
+                        <div className="flex items-center">
                           <img
                             alt=""
                             width="20"
@@ -154,38 +254,105 @@ const BalancesTable = () => {
                           />
 
                           {balance.symbol}
-                        </Td>
-                        <Td
-                          className={`px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {balance.deposits.toFixed()}
-                        </Td>
-                        <Td
-                          className={`px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {balance.borrows.toFixed()}
-                        </Td>
-                        <Td
-                          className={`px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {balance.orders}
-                        </Td>
-                        <Td
-                          className={`px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {balance.unsettled}
-                        </Td>
-                        <Td
-                          className={`px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {balance.net.toFixed()}
-                        </Td>
-                      </Tr>
-                    )
-                  })}
-                </Tbody>
+                        </div>
+                      </Td>
+                      <Td>{balance.deposits.toFixed()}</Td>
+                      <Td>{balance.borrows.toFixed()}</Td>
+                      <Td>{balance.orders}</Td>
+                      <Td>{balance.unsettled}</Td>
+                      <Td>{balance.net.toFixed()}</Td>
+                      <Td>{formatUsdValue(balance.value)}</Td>
+                    </TrBody>
+                  ))}
+                </tbody>
               </Table>
-            </div>
+            ) : (
+              <>
+                <div className="grid grid-cols-12 grid-rows-1 gap-4 pb-2 pt-4 px-3">
+                  <div className="col-span-7 text-fgd-3 text-xs">Asset</div>
+                  <div className="col-span-4 text-fgd-3 text-right text-xs">
+                    Net Balance
+                  </div>
+                </div>
+                {items.map((balance, index) => (
+                  <Disclosure key={balance.symbol}>
+                    {({ open }) => (
+                      <>
+                        <Disclosure.Button
+                          className={`${
+                            index % 2 === 0 ? `bg-th-bkg-4` : `bg-th-bkg-3`
+                          } default-transition font-normal p-3 rounded-none text-th-fgd-1 w-full hover:filter hover:brightness-105 focus:outline-none`}
+                        >
+                          <div className="grid grid-cols-12 grid-rows-1 gap-4">
+                            <div className="col-span-7 flex items-center text-fgd-1">
+                              <img
+                                alt=""
+                                width="20"
+                                height="20"
+                                src={`/assets/icons/${balance.symbol.toLowerCase()}.svg`}
+                                className={`mr-2.5`}
+                              />
+
+                              {balance.symbol}
+                            </div>
+                            <div className="col-span-4 text-fgd-1 text-right">
+                              {balance.net.toFixed()}
+                            </div>
+                            <div className="flex justify-end">
+                              <ChevronDownIcon
+                                className={`${
+                                  open
+                                    ? 'transform rotate-180'
+                                    : 'transform rotate-360'
+                                } default-transition h-5 flex-shrink-0 w-5 text-th-primary`}
+                              />
+                            </div>
+                          </div>
+                        </Disclosure.Button>
+                        <Disclosure.Panel
+                          className={`${
+                            index % 2 === 0 ? `bg-th-bkg-4` : `bg-th-bkg-3`
+                          } px-3`}
+                        >
+                          <div className="border-t border-[rgba(255,255,255,0.2)] grid grid-cols-2 grid-rows-1 gap-4 py-3">
+                            <div className="col-span-1 text-fgd-3 text-left">
+                              <div className="pb-0.5 text-th-fgd-3 text-xs">
+                                Deposits
+                              </div>
+                              {balance.deposits.toFixed()}
+                            </div>
+                            <div className="col-span-1 text-fgd-3 text-left">
+                              <div className="pb-0.5 text-th-fgd-3 text-xs">
+                                Borrows
+                              </div>
+                              {balance.borrows.toFixed()}
+                            </div>
+                            <div className="col-span-1 text-fgd-3 text-left">
+                              <div className="pb-0.5 text-th-fgd-3 text-xs">
+                                In Orders
+                              </div>
+                              {balance.orders.toFixed()}
+                            </div>
+                            <div className="col-span-1 text-fgd-3 text-left">
+                              <div className="pb-0.5 text-th-fgd-3 text-xs">
+                                Unsettled
+                              </div>
+                              {balance.unsettled.toFixed()}
+                            </div>
+                            <div className="col-span-1 text-fgd-3 text-left">
+                              <div className="pb-0.5 text-th-fgd-3 text-xs">
+                                Value
+                              </div>
+                              {formatUsdValue(balance.value)}
+                            </div>
+                          </div>
+                        </Disclosure.Panel>
+                      </>
+                    )}
+                  </Disclosure>
+                ))}
+              </>
+            )
           ) : (
             <div
               className={`w-full text-center py-6 bg-th-bkg-1 text-th-fgd-3 rounded-md`}

--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -15,12 +15,13 @@ import { floorToDecimal, formatUsdValue } from '../utils'
 import { Table, Td, Th, TrBody, TrHead } from './TableElements'
 import { useSortableData } from '../hooks/useSortableData'
 
-const BalancesTable = () => {
+const BalancesTable = ({ showZeroBalances = false }) => {
   const balances = useBalances()
   const { items, requestSort, sortConfig } = useSortableData(
     balances
       .filter(
         (bal) =>
+          showZeroBalances ||
           +bal.deposits > 0 ||
           +bal.borrows > 0 ||
           bal.orders > 0 ||
@@ -33,7 +34,7 @@ const BalancesTable = () => {
   const mangoGroupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
   const { width } = useViewport()
   const [submitting, setSubmitting] = useState(false)
-  const isMobile = width < breakpoints.sm
+  const isMobile = width ? width < breakpoints.md : false
 
   async function handleSettleAll() {
     const mangoAccount = useMangoStore.getState().selectedMangoAccount.current

--- a/components/TableElements.tsx
+++ b/components/TableElements.tsx
@@ -1,0 +1,30 @@
+export const Table = ({ children }) => (
+  <table className="min-w-full divide-y divide-th-bkg-2">{children}</table>
+)
+
+export const TrHead = ({ children }) => (
+  <tr className="text-th-fgd-3 text-xs">{children}</tr>
+)
+
+export const Th = ({ children }) => (
+  <th className="px-6 py-2 text-left font-normal" scope="col">
+    {children}
+  </th>
+)
+
+export const TrBody = ({ children, index, key }) => (
+  <tr
+    className={`border-b border-th-bkg-3
+    ${index % 2 === 0 ? `bg-th-bkg-4` : `bg-th-bkg-3`}
+    `}
+    key={key}
+  >
+    {children}
+  </tr>
+)
+
+export const Td = ({ children }) => (
+  <td className="px-6 py-3.5 whitespace-nowrap text-sm text-th-fgd-1">
+    {children}
+  </td>
+)

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -7,7 +7,7 @@ import useMangoStore from '../stores/useMangoStore'
 import ConnectWalletButton from './ConnectWalletButton'
 import NavDropMenu from './NavDropMenu'
 import AccountsModal from './AccountsModal'
-import MobileMenu from './MobileMenu'
+import MobileMenu from './mobile/MobileMenu'
 
 const TopBar = () => {
   const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)

--- a/components/TradeHistoryTable.tsx
+++ b/components/TradeHistoryTable.tsx
@@ -30,7 +30,10 @@ const TradeHistoryTable = () => {
   }
 
   return (
-    <div className="flex flex-col py-4">
+    <div className="flex flex-col mt-4">
+      <div className="text-th-fgd-4 -mt-2 mb-4">
+        Total trades: {tradeHistory.length}
+      </div>
       <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div className="align-middle inline-block min-w-full sm:px-6 lg:px-8">
           {tradeHistory && tradeHistory.length ? (

--- a/components/TradePageGrid.tsx
+++ b/components/TradePageGrid.tsx
@@ -68,7 +68,7 @@ export const defaultLayouts = {
 }
 
 export const GRID_LAYOUT_KEY = 'mangoSavedLayouts-3.0.8'
-const breakpoints = { xl: 1600, lg: 1200, md: 1110, sm: 768, xs: 0 }
+export const breakpoints = { xl: 1600, lg: 1200, md: 1110, sm: 768, xs: 0 }
 
 const TradePageGrid = () => {
   const { uiLocked } = useMangoStore((s) => s.settings)

--- a/components/UserInfo.tsx
+++ b/components/UserInfo.tsx
@@ -8,6 +8,7 @@ import BalancesTable from './BalancesTable'
 import PositionsTable from './PerpPositionsTable'
 import TradeHistoryTable from './TradeHistoryTable'
 // import FeeDiscountsTable from './FeeDiscountsTable'
+import Select from './Select'
 
 const TABS = [
   'Balances',
@@ -21,6 +22,7 @@ const UserInfoTabs = ({ activeTab, setActiveTab }) => {
   const openOrders = useOpenOrders()
   const perpPositions = usePerpPositions()
   const handleTabChange = (tabName) => {
+    console.log(tabName)
     setActiveTab(tabName)
   }
 
@@ -30,18 +32,13 @@ const UserInfoTabs = ({ activeTab, setActiveTab }) => {
         <label htmlFor="tabs" className={`sr-only`}>
           Select a tab
         </label>
-        <select
-          id="tabs"
-          name="tabs"
-          className={`block w-full pl-3 pr-10 py-2 bg-th-bkg-2 border border-th-fgd-4 focus:outline-none sm:text-sm rounded-md`}
-          onChange={(e) => handleTabChange(e.target.value)}
-        >
+        <Select onChange={(t) => handleTabChange(t)} value={activeTab}>
           {TABS.map((tabName) => (
-            <option key={tabName} value={tabName}>
+            <Select.Option key={tabName} value={tabName}>
               {tabName}
-            </option>
+            </Select.Option>
           ))}
-        </select>
+        </Select>
       </div>
       <div className={`hidden sm:block`}>
         <div className={`border-b border-th-fgd-4`}>

--- a/components/account-page/AccountHistory.tsx
+++ b/components/account-page/AccountHistory.tsx
@@ -7,8 +7,8 @@ export default function AccountHistory() {
   const [view] = useState('Trades')
   return (
     <>
-      <div className="flex items-center justify-between pb-3.5 sm:pt-1">
-        <div className="text-th-fgd-1 text-lg">{view.slice(0, -1)} History</div>
+      <div className="flex items-center justify-between mb-3 sm:mt-1">
+        <div className="text-th-fgd-1 text-lg">Trade History</div>
         {/* Todo: add this back when the data is available */}
         {/* <div className="flex">
           {historyViews.map((section) => (

--- a/components/account-page/AccountOverview.tsx
+++ b/components/account-page/AccountOverview.tsx
@@ -1,153 +1,33 @@
-import { useEffect, useCallback, useMemo, useState } from 'react'
-import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
+import { useMemo } from 'react'
 import styled from '@emotion/styled'
 import {
   // ChartBarIcon,
   ScaleIcon,
   CurrencyDollarIcon,
-  ExclamationIcon,
   GiftIcon,
   HeartIcon,
 } from '@heroicons/react/outline'
-import { ArrowSmDownIcon } from '@heroicons/react/solid'
-import {
-  getTokenBySymbol,
-  nativeToUi,
-  ZERO_BN,
-  I80F48,
-} from '@blockworks-foundation/mango-client'
+import { nativeToUi, ZERO_BN } from '@blockworks-foundation/mango-client'
 import useMangoStore, {
   mangoClient,
   MNGO_INDEX,
 } from '../../stores/useMangoStore'
-import { useBalances } from '../../hooks/useBalances'
-import { useSortableData } from '../../hooks/useSortableData'
-import useLocalStorageState from '../../hooks/useLocalStorageState'
-import {
-  sleep,
-  tokenPrecision,
-  formatUsdValue,
-  floorToDecimal,
-} from '../../utils'
+import { formatUsdValue } from '../../utils'
 import { notify } from '../../utils/notifications'
-import { Market } from '@project-serum/serum'
-import Button, { LinkButton } from '../Button'
-import Switch from '../Switch'
+import { LinkButton } from '../Button'
+import BalancesTable from '../BalancesTable'
 import PositionsTable from '../PerpPositionsTable'
-import DepositModal from '../DepositModal'
-import WithdrawModal from '../WithdrawModal'
 
 const StyledAccountValue = styled.div`
   font-size: 1.8rem;
   line-height: 1.2;
 `
 
-const SHOW_ZERO_BALANCE_KEY = 'showZeroAccountBalances-0.1'
-
 export default function AccountOverview() {
-  const [spotPortfolio, setSpotPortfolio] = useState([])
-  const [unsettled, setUnsettled] = useState([])
-  const [filteredSpotPortfolio, setFilteredSpotPortfolio] = useState([])
-  const [showZeroBalances, setShowZeroBalances] = useLocalStorageState(
-    SHOW_ZERO_BALANCE_KEY,
-    true
-  )
-  const [showDepositModal, setShowDepositModal] = useState(false)
-  const [showWithdrawModal, setShowWithdrawModal] = useState(false)
-  const [actionSymbol, setActionSymbol] = useState('')
-  const balances = useBalances()
   const actions = useMangoStore((s) => s.actions)
-  const groupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
   const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const mangoCache = useMangoStore((s) => s.selectedMangoGroup.cache)
-  const mangoGroupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
-  const { items, requestSort, sortConfig } = useSortableData(
-    filteredSpotPortfolio
-  )
-
-  useEffect(() => {
-    const spotPortfolio = []
-    const unsettled = []
-    balances.forEach((b) => {
-      const token = getTokenBySymbol(groupConfig, b.symbol)
-      const tokenIndex = mangoGroup.getTokenIndex(token.mintKey)
-      if (+b.deposits > 0) {
-        spotPortfolio.push({
-          market: b.symbol,
-          balance: +b.deposits,
-          borrowRate: mangoGroup
-            .getBorrowRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          depositRate: mangoGroup
-            .getDepositRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          orders: b.orders ? b.orders : 0,
-          unsettled: b.unsettled ? b.unsettled : 0,
-          net: b.net ? b.net : 0,
-          price: mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-          symbol: b.symbol,
-          value:
-            +b.net * mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-        })
-      } else if (+b.borrows > 0) {
-        spotPortfolio.push({
-          market: b.symbol,
-          balance: +b.borrows * -1,
-          borrowRate: mangoGroup
-            .getBorrowRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          depositRate: mangoGroup
-            .getDepositRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          orders: b.orders ? b.orders : 0,
-          unsettled: b.unsettled ? b.unsettled : 0,
-          net: b.net ? b.net : 0,
-          price: mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-          symbol: b.symbol,
-          value:
-            +b.net * mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-        })
-      } else {
-        spotPortfolio.push({
-          market: b.symbol,
-          balance: 0,
-          borrowRate: mangoGroup
-            .getBorrowRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          depositRate: mangoGroup
-            .getDepositRate(tokenIndex)
-            .mul(I80F48.fromNumber(100)),
-          orders: b.orders ? b.orders : 0,
-          unsettled: b.unsettled ? b.unsettled : 0,
-          net: b.net ? b.net : 0,
-          price: mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-          symbol: b.symbol,
-          value: 0,
-        })
-      }
-      if (b.unsettled > 0) {
-        unsettled.push({
-          market: b.symbol,
-          balance: b.unsettled,
-          symbol: b.symbol,
-          value:
-            b.unsettled *
-            mangoGroup.getPrice(tokenIndex, mangoCache).toNumber(),
-        })
-      }
-    })
-    setSpotPortfolio(spotPortfolio.sort((a, b) => b.value - a.value))
-    setFilteredSpotPortfolio(
-      !showZeroBalances
-        ? spotPortfolio
-            .filter((pos) => pos.balance !== 0 && Math.abs(pos.value) > 0.001)
-            .sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
-        : spotPortfolio.sort((a, b) => Math.abs(b.value) - Math.abs(a.value))
-    )
-
-    setUnsettled(unsettled)
-  }, [mangoAccount, showZeroBalances])
 
   const maintHealthRatio = useMemo(() => {
     return mangoAccount
@@ -168,47 +48,6 @@ export default function AccountOverview() {
         }, ZERO_BN)
       : ZERO_BN
   }, [mangoAccount])
-
-  const handleShowZeroBalances = (checked) => {
-    if (checked) {
-      setFilteredSpotPortfolio(spotPortfolio)
-    } else {
-      setFilteredSpotPortfolio(spotPortfolio.filter((pos) => pos.balance !== 0))
-    }
-    setShowZeroBalances(checked)
-  }
-
-  async function handleSettleAll() {
-    const mangoAccount = useMangoStore.getState().selectedMangoAccount.current
-    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
-    const markets = useMangoStore.getState().selectedMangoGroup.markets
-    const wallet = useMangoStore.getState().wallet.current
-
-    try {
-      const spotMarkets = Object.values(markets).filter(
-        (mkt) => mkt instanceof Market
-      ) as Market[]
-      await mangoClient.settleAll(mangoGroup, mangoAccount, spotMarkets, wallet)
-      notify({ title: 'Successfully settled funds' })
-      await sleep(250)
-      actions.fetchMangoAccounts()
-    } catch (e) {
-      console.warn('Error settling all:', e)
-      if (e.message === 'No unsettled funds') {
-        notify({
-          title: 'There are no unsettled funds',
-          type: 'error',
-        })
-      } else {
-        notify({
-          title: 'Error settling funds',
-          description: e.message,
-          txid: e.txid,
-          type: 'error',
-        })
-      }
-    }
-  }
 
   const handleRedeemMngo = async () => {
     const wallet = useMangoStore.getState().wallet.current
@@ -239,16 +78,6 @@ export default function AccountOverview() {
       })
     }
   }
-
-  const handleOpenDepositModal = useCallback((symbol) => {
-    setActionSymbol(symbol)
-    setShowDepositModal(true)
-  }, [])
-
-  const handleOpenWithdrawModal = useCallback((symbol) => {
-    setActionSymbol(symbol)
-    setShowWithdrawModal(true)
-  }, [])
 
   return mangoAccount ? (
     <>
@@ -359,320 +188,8 @@ export default function AccountOverview() {
           </div>
         </div>
       </div>
-      <div className="flex justify-between pb-4">
-        <div className="text-th-fgd-1 text-lg">Balances</div>
-        <Switch
-          checked={showZeroBalances}
-          className="text-xs"
-          onChange={handleShowZeroBalances}
-        >
-          Show zero and dust balances
-        </Switch>
-      </div>
-      {unsettled.length > 0 ? (
-        <div className="border border-th-bkg-3 rounded-lg mb-4 p-6">
-          <div className="flex items-center justify-between pb-4">
-            <div className="flex items-center text-lg">
-              <ExclamationIcon className="h-5 mr-1.5 mt-0.5 text-th-primary w-5" />
-              Unsettled Balances
-            </div>
-            <Button
-              className="text-xs pt-0 pb-0 h-8 pl-3 pr-3"
-              onClick={handleSettleAll}
-            >
-              Settle All
-            </Button>
-          </div>
-          {unsettled.map((a) => {
-            const tokenConfig = getTokenBySymbol(mangoGroupConfig, a.symbol)
-            return (
-              <div
-                className="border-b border-th-bkg-4 flex items-center justify-between py-4 last:border-b-0 last:pb-0"
-                key={a.symbol}
-              >
-                <div className="flex items-center">
-                  <img
-                    alt=""
-                    width="20"
-                    height="20"
-                    src={`/assets/icons/${a.symbol.toLowerCase()}.svg`}
-                    className={`mr-2.5`}
-                  />
-                  <div>{a.symbol}</div>
-                </div>
-                {floorToDecimal(parseFloat(a.balance), tokenConfig.decimals)}
-              </div>
-            )
-          })}
-        </div>
-      ) : null}
-      {filteredSpotPortfolio.length > 0 ? (
-        <div className="flex flex-col">
-          <div className="-mx-6">
-            <div className="align-middle inline-block min-w-full overflow-x-auto px-6">
-              <Table className="min-w-full divide-y divide-th-bkg-2">
-                <Thead>
-                  <Tr className="text-th-fgd-3 text-xs">
-                    <Th scope="col" className={`px-6 py-2 text-left`}>
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('market')}
-                      >
-                        Asset
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'market'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className={`px-6 py-2 text-left`}>
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('balance')}
-                      >
-                        Balance
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'balance'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className={`px-6 py-2 text-left`}>
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('orders')}
-                      >
-                        In Orders
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'orders'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className={`px-6 py-2 text-left`}>
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('unsettled')}
-                      >
-                        Unsettled
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'unsettled'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className={`px-6 py-2 text-left`}>
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('net')}
-                      >
-                        Net
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'net'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className="px-6 py-2 text-left">
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('value')}
-                      >
-                        Value
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'value'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className="px-6 py-2 text-left">
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('depositRate')}
-                      >
-                        Deposit Rate
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'depositRate'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                    <Th scope="col" className="px-6 py-2 text-left">
-                      <LinkButton
-                        className="flex font-normal items-center no-underline"
-                        onClick={() => requestSort('borrowRate')}
-                      >
-                        Borrow Rate
-                        <ArrowSmDownIcon
-                          className={`default-transition flex-shrink-0 h-4 w-4 ml-1 ${
-                            sortConfig?.key === 'borrowRate'
-                              ? sortConfig.direction === 'ascending'
-                                ? 'transform rotate-180'
-                                : 'transform rotate-360'
-                              : null
-                          }`}
-                        />
-                      </LinkButton>
-                    </Th>
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {items.map((pos, i) => {
-                    const tokenConfig = getTokenBySymbol(
-                      mangoGroupConfig,
-                      pos.symbol
-                    )
-                    return (
-                      <Tr
-                        key={i}
-                        className={`border-b border-th-bkg-3
-                  ${i % 2 === 0 ? `bg-th-bkg-3` : `bg-th-bkg-2`}
-                `}
-                      >
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          <div className="flex items-center">
-                            <img
-                              alt=""
-                              width="20"
-                              height="20"
-                              src={`/assets/icons/${pos.symbol.toLowerCase()}.svg`}
-                              className={`mr-2.5`}
-                            />
-                            <div>{pos.market}</div>
-                          </div>
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {pos.balance !== 0
-                            ? floorToDecimal(
-                                parseFloat(pos.balance),
-                                tokenConfig.decimals
-                              )
-                            : 0}
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {pos.orders !== 0
-                            ? pos.orders.toFixed(tokenPrecision[pos.symbol])
-                            : 0}
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {pos.unsettled !== 0
-                            ? floorToDecimal(
-                                parseFloat(pos.unsettled),
-                                tokenConfig.decimals
-                              )
-                            : 0}
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {pos.net !== 0
-                            ? floorToDecimal(
-                                parseFloat(pos.net),
-                                tokenConfig.decimals
-                              )
-                            : 0}
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-fgd-1`}
-                        >
-                          {formatUsdValue(pos.value)}
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-green`}
-                        >
-                          {pos.depositRate.toFixed(2)}%
-                        </Td>
-                        <Td
-                          className={`px-6 py-2 whitespace-nowrap text-sm text-th-red`}
-                        >
-                          {pos.borrowRate.toFixed(2)}%
-                        </Td>
-                        <Td className={`px-6 py-2 flex justify-end`}>
-                          <Button
-                            className="text-xs pt-0 pb-0 h-8 pl-3 pr-3"
-                            onClick={() => handleOpenDepositModal(pos.symbol)}
-                          >
-                            Deposit
-                          </Button>
-                          <Button
-                            className="text-xs pt-0 pb-0 h-8 ml-4 pl-3 pr-3"
-                            onClick={() => handleOpenWithdrawModal(pos.symbol)}
-                          >
-                            Withdraw
-                          </Button>
-                        </Td>
-                      </Tr>
-                    )
-                  })}
-                </Tbody>
-              </Table>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div
-          className={`w-full text-center py-6 bg-th-bkg-1 text-th-fgd-3 rounded-md`}
-        >
-          No assets
-        </div>
-      )}
-      {showDepositModal && (
-        <DepositModal
-          isOpen={showDepositModal}
-          onClose={() => setShowDepositModal(false)}
-          tokenSymbol={actionSymbol}
-        />
-      )}
-      {showWithdrawModal && (
-        <WithdrawModal
-          isOpen={showWithdrawModal}
-          onClose={() => setShowWithdrawModal(false)}
-          tokenSymbol={actionSymbol}
-        />
-      )}
+      <div className="text-th-fgd-1 text-lg">Balances</div>
+      <BalancesTable />
     </>
   ) : null
 }

--- a/components/account-page/AccountOverview.tsx
+++ b/components/account-page/AccountOverview.tsx
@@ -17,17 +17,24 @@ import { notify } from '../../utils/notifications'
 import { LinkButton } from '../Button'
 import BalancesTable from '../BalancesTable'
 import PositionsTable from '../PerpPositionsTable'
+import Switch from '../Switch'
+import useLocalStorageState from '../../hooks/useLocalStorageState'
 
 const StyledAccountValue = styled.div`
   font-size: 1.8rem;
   line-height: 1.2;
 `
+const SHOW_ZERO_BALANCE_KEY = 'showZeroAccountBalances-0.2'
 
 export default function AccountOverview() {
   const actions = useMangoStore((s) => s.actions)
   const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const mangoCache = useMangoStore((s) => s.selectedMangoGroup.cache)
+  const [showZeroBalances, setShowZeroBalances] = useLocalStorageState(
+    SHOW_ZERO_BALANCE_KEY,
+    true
+  )
 
   const maintHealthRatio = useMemo(() => {
     return mangoAccount
@@ -188,8 +195,17 @@ export default function AccountOverview() {
           </div>
         </div>
       </div>
-      <div className="text-th-fgd-1 text-lg">Balances</div>
-      <BalancesTable />
+      <div className="flex justify-between pb-4">
+        <div className="text-th-fgd-1 text-lg">Balances</div>
+        <Switch
+          checked={showZeroBalances}
+          className="text-xs"
+          onChange={() => setShowZeroBalances(!showZeroBalances)}
+        >
+          Show zero and dust balances
+        </Switch>
+      </div>
+      <BalancesTable showZeroBalances={showZeroBalances} />
     </>
   ) : null
 }

--- a/components/mobile/MobileMenu.tsx
+++ b/components/mobile/MobileMenu.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { Transition } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
-import MenuItem from './MenuItem'
-import ConnectWalletButton from './ConnectWalletButton'
-import { IconButton } from './Button'
+import MenuItem from '../MenuItem'
+import ConnectWalletButton from '../ConnectWalletButton'
+import { IconButton } from '../Button'
 
 const MobileMenu = () => {
   const [showMenu, setShowMenu] = useState(false)

--- a/components/stats-page/StatsTotals.tsx
+++ b/components/stats-page/StatsTotals.tsx
@@ -1,9 +1,13 @@
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
 import { I80F48 } from '@blockworks-foundation/mango-client'
 import Chart from '../Chart'
+import { tokenPrecision } from '../../utils'
 
-function formatNumberString(x: string): string {
-  return x.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')
+function formatNumberString(x: number, decimals): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  }).format(x)
 }
 
 export default function StatsTotals({ latestStats, stats }) {
@@ -160,20 +164,27 @@ export default function StatsTotals({ latestStats, stats }) {
                   </div>
                 </Td>
                 <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
-                  {formatNumberString(stat.totalDeposits)}
-                </Td>
-                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
-                  {formatNumberString(stat.totalBorrows)}
-                </Td>
-                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
-                  {formatNumberString(stat.depositInterest.toFixed(2))}%
-                </Td>
-                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
-                  {formatNumberString(stat.borrowInterest.toFixed(2))}%
+                  {formatNumberString(
+                    stat.totalDeposits,
+                    tokenPrecision[stat.name]
+                  )}
                 </Td>
                 <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
                   {formatNumberString(
-                    stat.utilization.mul(I80F48.fromNumber(100)).toFixed(2)
+                    stat.totalBorrows,
+                    tokenPrecision[stat.name]
+                  )}
+                </Td>
+                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
+                  {formatNumberString(stat.depositInterest.toNumber(), 2)}%
+                </Td>
+                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
+                  {formatNumberString(stat.borrowInterest.toNumber(), 2)}%
+                </Td>
+                <Td className="px-6 py-4 whitespace-nowrap text-sm text-th-fgd-1">
+                  {formatNumberString(
+                    stat.utilization.mul(I80F48.fromNumber(100)).toNumber(),
+                    2
                   )}
                   %
                 </Td>

--- a/hooks/useBalances.tsx
+++ b/hooks/useBalances.tsx
@@ -1,5 +1,6 @@
 import { Balances } from '../@types/types'
 import {
+  getTokenBySymbol,
   nativeI80F48ToUi,
   nativeToUi,
   QUOTE_INDEX,
@@ -69,6 +70,14 @@ export function useBalances(): Balances[] {
       return amount
     }
 
+    const value = (nativeBaseLocked, tokenIndex) => {
+      const amount = mangoGroup
+        .getPrice(tokenIndex, mangoCache)
+        .mul(net(nativeBaseLocked, tokenIndex))
+
+      return amount
+    }
+
     const marketPair = [
       {
         market: null,
@@ -93,6 +102,7 @@ export function useBalances(): Balances[] {
           mangoGroup.tokens[tokenIndex].decimals
         ),
         net: net(nativeBaseLocked, tokenIndex),
+        value: value(nativeBaseLocked, tokenIndex),
       },
       {
         market: null,
@@ -117,6 +127,7 @@ export function useBalances(): Balances[] {
           mangoGroup.tokens[quoteCurrencyIndex].decimals
         ),
         net: net(nativeQuoteLocked, quoteCurrencyIndex),
+        value: value(nativeQuoteLocked, quoteCurrencyIndex),
       },
     ]
     balances.push(marketPair)
@@ -133,6 +144,11 @@ export function useBalances(): Balances[] {
     .sub(quoteMeta.borrows)
     .add(I80F48.fromNumber(quoteInOrders))
 
+  const token = getTokenBySymbol(mangoGroupConfig, quoteMeta.symbol)
+  const tokenIndex = mangoGroup.getTokenIndex(token.mintKey)
+
+  const value = net.mul(mangoGroup.getPrice(tokenIndex, mangoCache))
+
   return [
     {
       market: null,
@@ -143,6 +159,7 @@ export function useBalances(): Balances[] {
       orders: quoteInOrders,
       unsettled,
       net,
+      value,
     },
   ].concat(baseBalances)
 }

--- a/hooks/useViewport.tsx
+++ b/hooks/useViewport.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type ViewportContextProps = {
+  width: number
+}
+
+const ViewportContext = createContext({} as ViewportContextProps)
+
+export const ViewportProvider = ({ children }) => {
+  const [mounted, setMounted] = useState(false)
+  const [width, setWidth] = useState(null)
+
+  const handleWindowResize = () => {
+    setWidth(window.innerWidth)
+  }
+
+  useEffect(() => {
+    window.addEventListener('resize', handleWindowResize)
+    return () => window.removeEventListener('resize', handleWindowResize)
+  }, [])
+
+  useEffect(() => setMounted(true), [])
+  if (!mounted) return null
+
+  return (
+    <ViewportContext.Provider value={{ width }}>
+      {children}
+    </ViewportContext.Provider>
+  )
+}
+
+export const useViewport = () => {
+  const { width } = useContext(ViewportContext)
+  return { width }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import '../styles/index.css'
 import useWallet from '../hooks/useWallet'
 import useHydrateStore from '../hooks/useHydrateStore'
 import Notifications from '../components/Notification'
+import { ViewportProvider } from '../hooks/useViewport'
 
 function App({ Component, pageProps }) {
   useHydrateStore()
@@ -47,10 +48,12 @@ function App({ Component, pageProps }) {
         <link rel="manifest" href="/manifest.json"></link>
       </Head>
       <ThemeProvider defaultTheme="Mango">
-        <div className="bg-th-bkg-1">
-          <Component {...pageProps} />
-        </div>
-        <Notifications />
+        <ViewportProvider>
+          <div className="bg-th-bkg-1">
+            <Component {...pageProps} />
+          </div>
+          <Notifications />
+        </ViewportProvider>
       </ThemeProvider>
     </>
   )

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -7,7 +7,7 @@ import {
   PencilIcon,
 } from '@heroicons/react/outline'
 import useMangoStore from '../stores/useMangoStore'
-import { abbreviateAddress, copyToClipboard } from '../utils'
+import { copyToClipboard } from '../utils'
 import PageBodyContainer from '../components/PageBodyContainer'
 import TopBar from '../components/TopBar'
 import AccountAssets from '../components/account-page/AccountAssets'
@@ -69,15 +69,17 @@ export default function Account() {
     <div className={`bg-th-bkg-1 text-th-fgd-1 transition-all`}>
       <TopBar />
       <PageBodyContainer>
-        <div className="flex flex-col sm:flex-row items-center justify-between pt-8 pb-3 sm:pb-6 md:pt-10">
+        <div className="flex flex-col sm:flex-row items-center justify-between pt-8 pb-3 sm:pb-3 md:pt-10">
           {mangoAccount ? (
             <>
-              <div className="flex flex-col sm:flex-row sm:items-end pb-4 md:pb-0">
+              <div className="flex flex-col md:flex-row md:items-end pb-2 md:pb-0">
                 <h1 className={`font-semibold mr-3 text-th-fgd-1 text-2xl`}>
                   {mangoAccount?.name || 'Account'}
                 </h1>
                 <div className="flex items-center pb-0.5 text-th-fgd-3 ">
-                  {abbreviateAddress(mangoAccount.publicKey)}
+                  <span className="text-xxs">
+                    {mangoAccount.publicKey.toString()}
+                  </span>
                   <DuplicateIcon
                     className="cursor-pointer default-transition h-4 w-4 ml-1.5 hover:text-th-fgd-1"
                     onClick={() => handleCopyPublicKey(mangoAccount.publicKey)}


### PR DESCRIPTION
Keen to improve all of the tables on mobile. We could do expanding rows with only the most useful info displayed on the row and the rest within the expandable panel.

• Added a hook to conditionally render based on breakpoints – we had been using 'hidden' tailwind class but I find this harder to maintain and less flexible than having a variable.

• Added balance value to what gets returned from useBalances and enabled sorting on the balances table.