### PR TITLE
Add Tradingview Order Lines

### DIFF
--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTheme } from 'next-themes'
 import {
   widget,
@@ -6,9 +6,14 @@ import {
   IChartingLibraryWidget,
   ResolutionString,
 } from '../charting_library' // Make sure to follow step 1 of the README
-// import { useMarket } from '../../utils/markets';
 import { CHART_DATA_FEED } from '../../utils/chartDataConnector'
-import useMangoStore from '../../stores/useMangoStore'
+import useMangoStore, { mangoClient } from '../../stores/useMangoStore'
+import { useOpenOrders } from '../../hooks/useOpenOrders'
+import { useSortableData } from '../../hooks/useSortableData'
+import { Order, Market } from '@project-serum/serum/lib/market'
+import { PerpOrder, PerpMarket } from '@blockworks-foundation/mango-client'
+import { notify } from '../../utils/notifications'
+import { sleep } from '../../utils'
 
 // This is a basic example of how to create a TV widget
 // You can add more feature such as storing charts in localStorage
@@ -35,6 +40,18 @@ const TVChartContainer = () => {
   const selectedMarketConfig = useMangoStore((s) => s.selectedMarket.config)
   const { theme } = useTheme()
 
+  const selectedMarketName = selectedMarketConfig.name
+  const openOrders = useOpenOrders()
+  const { items } = useSortableData(openOrders)
+  const actions = useMangoStore((s) => s.actions)
+  const connected = useMangoStore((s) => s.wallet.connected)
+  const selectedMarginAccount =
+    useMangoStore.getState().selectedMangoAccount.current
+  const selectedMarketPrice = useMangoStore((s) => s.selectedMarket.markPrice)
+  const [lines, setLines] = useState(new Map())
+  const [moveInProgress, toggleMoveInProgress] = useState(false)
+
+  
   // @ts-ignore
   const defaultProps: ChartContainerProps = {
     symbol: selectedMarketConfig.name,
@@ -123,26 +140,317 @@ const TVChartContainer = () => {
 
     const tvWidget = new widget(widgetOptions)
     tvWidgetRef.current = tvWidget
-
-    tvWidget.onChartReady(() => {
-      // tvWidget.headerReady().then(() => {
-      // const button = tvWidget.createButton()
-      // button.setAttribute('title', 'Click to show a notification popup')
-      // button.classList.add('apply-common-tooltip')
-      // button.addEventListener('click', () =>
-      //   tvWidget.showNoticeDialog({
-      //     title: 'Notification',
-      //     body: 'TradingView Charting Library API works correctly',
-      //     callback: () => {
-      //       // console.log('It works!!');
-      //     },
-      //   })
-      // )
-      // button.innerHTML = 'Check API'
-      // })
-    })
-    //eslint-disable-next-line
   }, [selectedMarketConfig, theme])
+
+  
+  const handleCancelOrder = async ( 
+    order: Order | PerpOrder,
+    market: Market | PerpMarket
+  ) => {
+    const wallet = useMangoStore.getState().wallet.current
+    const selectedMangoGroup =
+      useMangoStore.getState().selectedMangoGroup.current
+    const selectedMangoAccount =
+      useMangoStore.getState().selectedMangoAccount.current
+
+    let txid
+    try {
+      if (!selectedMangoGroup || !selectedMangoAccount) return
+      if (market instanceof Market) {
+        txid = await mangoClient.cancelSpotOrder(
+          selectedMangoGroup,
+          selectedMangoAccount,
+          wallet,
+          market,
+          order as Order
+        )
+      } else if (market instanceof PerpMarket) {
+        txid = await mangoClient.cancelPerpOrder(
+          selectedMangoGroup,
+          selectedMangoAccount,
+          wallet,
+          market,
+          order as PerpOrder
+        )
+      }
+      notify({ title: 'Successfully cancelled order', txid })
+    } catch (e) {
+      notify({
+        title: 'Error cancelling order',
+        description: e.message,
+        txid: e.txid,
+        type: 'error',
+      })
+      return false
+    } finally {
+      sleep(500).then(() => {
+        actions.fetchMangoAccounts()
+        actions.updateOpenOrders()
+      })
+    }
+  }
+
+
+  const handleModifyOrder = async (
+    order: Order | PerpOrder,
+    market: Market | PerpMarket,
+    price: number
+  ) => {
+    const mangoAccount = useMangoStore.getState().selectedMangoAccount.current
+    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
+    const { askInfo, bidInfo } = useMangoStore.getState().selectedMarket
+    const wallet = useMangoStore.getState().wallet.current
+
+    if (!wallet || !mangoGroup || !mangoAccount || !market) return
+
+    try {
+      const orderPrice = price
+
+      if (!orderPrice) {
+        notify({
+          title: 'Price not available',
+          description: 'Please try again',
+          type: 'error',
+        })
+      }
+      const orderType = 'limit'
+      let txid
+      if (market instanceof Market) {
+        txid = await mangoClient.modifySpotOrder(
+          mangoGroup,
+          mangoAccount,
+          mangoGroup.mangoCache,
+          market,
+          wallet,
+          order.side,
+          orderPrice,
+          order.size,
+          orderType
+        )
+      } else {
+        txid = await mangoClient.modifyPerpOrder(
+          mangoGroup,
+          mangoAccount,
+          mangoGroup.mangoCache,
+          market,
+          wallet,
+          order,
+          order.side,
+          orderPrice,
+          order.size,
+          orderType,
+          0,
+          order.side === 'buy' ? askInfo : bidInfo
+        )
+      }
+
+      notify({ title: 'Successfully placed trade', txid })
+    } catch (e) {
+      notify({
+        title: 'Error placing order',
+        description: e.message,
+        txid: e.txid,
+        type: 'error',
+      })
+    } finally {
+      sleep(1000).then(() => {
+        actions.fetchMangoAccounts()
+        actions.updateOpenOrders()
+      })
+    }
+  }
+
+
+  const handlePlaceOrder = async ( 
+    order: Order | PerpOrder,
+    market: Market | PerpMarket,
+    price: number
+  ) => {
+    const mangoAccount = useMangoStore.getState().selectedMangoAccount.current
+    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
+    const { askInfo, bidInfo } = useMangoStore.getState().selectedMarket
+    const wallet = useMangoStore.getState().wallet.current
+
+    if (!wallet || !mangoGroup || !mangoAccount || !market) return
+
+    try {
+      const orderPrice = price
+
+      if (!orderPrice) {
+        notify({
+          title: 'Price not available',
+          description: 'Please try again',
+          type: 'error',
+        })
+      }
+
+      const orderType = 'limit'
+      let txid
+      if (market instanceof Market) {
+        txid = await mangoClient.placeSpotOrder(
+          mangoGroup,
+          mangoAccount,
+          mangoGroup.mangoCache,
+          market,
+          wallet,
+          order.side,
+          orderPrice,
+          order.size,
+          orderType
+        )
+      } else {
+        txid = await mangoClient.placePerpOrder(
+          mangoGroup,
+          mangoAccount,
+          mangoGroup.mangoCache,
+          market,
+          wallet,
+          order.side,
+          orderPrice,
+          order.size,
+          orderType,
+          0,
+          order.side === 'buy' ? askInfo : bidInfo
+        )
+      }
+
+      notify({ title: 'Successfully placed trade', txid })
+    } catch (e) {
+      notify({
+        title: 'Error placing order',
+        description: e.message,
+        txid: e.txid,
+        type: 'error',
+      })
+    } finally {
+      sleep(1000).then(() => {
+        actions.fetchMangoAccounts()
+        actions.updateOpenOrders()
+      })
+    }
+  }
+
+
+  function getLine(order, market) {
+    return tvWidgetRef.current
+      .chart()
+      .createOrderLine({ disableUndo: false })
+      .onMove(function () {
+        const currentOrderPrice = order.price
+        const updatedOrderPrice = this.getPrice()
+        if (
+          (order.side === 'buy' &&
+            updatedOrderPrice > 1.05 * selectedMarketPrice) ||
+          (order.side === 'sell' &&
+            updatedOrderPrice < 0.95 * selectedMarketPrice)
+        ) {
+          toggleMoveInProgress(true)
+          tvWidgetRef.current.showNoticeDialog({
+            title: 'Order Price Outside Range',
+            body:
+              `Your order price ($${updatedOrderPrice.toFixed(
+                2
+              )}) is greater than 5% ${
+                order.side == 'buy' ? 'above' : 'below'
+              } the current market price ($${selectedMarketPrice.toFixed(
+                2
+              )}). ` +
+              ' indicating you might incur significant slippage. <p><p>Please use the trade input form if you wish to accept the potential slippage.',
+            callback: () => {
+              this.setPrice(currentOrderPrice)
+              toggleMoveInProgress(false)
+            },
+          })
+        } else {
+          toggleMoveInProgress(true)
+          tvWidgetRef.current.showConfirmDialog({
+            title: 'Change Order Price?',
+            body: `Would you like to change your order from a 
+           ${order.size} ${market.config.baseSymbol} ${
+              order.side
+            } at $${currentOrderPrice} 
+           to a 
+          ${order.size} ${market.config.baseSymbol} ${
+              order.side
+            } at $${updatedOrderPrice}? Current market price is ${selectedMarketPrice} 
+          `,
+            callback: (res) => {
+              if (res) {
+//                handleModifyOrder(order, market.account, updatedOrderPrice)
+                handleCancelOrder(order, market.account)
+                handlePlaceOrder(order, market.account, updatedOrderPrice)
+              } else {
+                this.setPrice(currentOrderPrice)
+              }
+              toggleMoveInProgress(false)
+            },
+          })
+        }
+      })
+      .onCancel(function () {
+        toggleMoveInProgress(true)
+        tvWidgetRef.current.showConfirmDialog({
+          title: 'Cancel Your Order?',
+          body: `Would you like to cancel your order for 
+       ${order.size} ${market.config.baseSymbol} ${
+            order.side
+          } at $${order.price}  
+      `,
+          callback: (res) => {
+            if (res) {
+              handleCancelOrder(order, market.account)
+            }
+            toggleMoveInProgress(false)
+          },
+        })
+      })
+      .setText(
+        `${market.config.baseSymbol}`
+      )
+      .setBodyBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setBodyBackgroundColor('#000000')
+      .setBodyTextColor('#F2C94C')
+      .setLineLength(3)
+      .setLineColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setQuantity(order.size)
+      .setTooltip(`Order #: ${order.orderId}`)
+      .setQuantityBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setQuantityBackgroundColor('#000000')
+      .setQuantityTextColor('#F2C94C')
+      .setCancelButtonBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
+      .setCancelButtonBackgroundColor('#000000')
+      .setCancelButtonIconColor('#F2C94C')
+      .setPrice(order.price)
+  }
+
+  
+  useEffect(() => {
+    if (!moveInProgress) {
+      const tempLines = new Map()
+      tvWidgetRef.current.onChartReady(() => {
+        if (lines.size > 0) {
+          lines.forEach((value, key) => {
+            lines.get(key).remove()
+          })
+        }
+
+        items.map(({order, market}, index) => {
+          if (market.config.name == selectedMarketName) {
+            tempLines.set(order.orderId.toString(), getLine(order, market))
+          }
+        })
+      })
+      setLines(tempLines)
+    }
+  }, [
+    selectedMarginAccount,
+    connected,
+    selectedMarketName,
+    selectedMarketPrice,
+  ])
+
+
+
 
   return <div id={defaultProps.containerId} className="tradingview-chart" />
 }

--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -222,6 +222,7 @@ const TVChartContainer = () => {
           mangoGroup.mangoCache,
           market,
           wallet,
+          order,
           order.side,
           orderPrice,
           order.size,
@@ -235,76 +236,6 @@ const TVChartContainer = () => {
           market,
           wallet,
           order,
-          order.side,
-          orderPrice,
-          order.size,
-          orderType,
-          0,
-          order.side === 'buy' ? askInfo : bidInfo
-        )
-      }
-
-      notify({ title: 'Successfully placed trade', txid })
-    } catch (e) {
-      notify({
-        title: 'Error placing order',
-        description: e.message,
-        txid: e.txid,
-        type: 'error',
-      })
-    } finally {
-      sleep(1000).then(() => {
-        actions.fetchMangoAccounts()
-        actions.updateOpenOrders()
-      })
-    }
-  }
-
-
-  const handlePlaceOrder = async ( 
-    order: Order | PerpOrder,
-    market: Market | PerpMarket,
-    price: number
-  ) => {
-    const mangoAccount = useMangoStore.getState().selectedMangoAccount.current
-    const mangoGroup = useMangoStore.getState().selectedMangoGroup.current
-    const { askInfo, bidInfo } = useMangoStore.getState().selectedMarket
-    const wallet = useMangoStore.getState().wallet.current
-
-    if (!wallet || !mangoGroup || !mangoAccount || !market) return
-
-    try {
-      const orderPrice = price
-
-      if (!orderPrice) {
-        notify({
-          title: 'Price not available',
-          description: 'Please try again',
-          type: 'error',
-        })
-      }
-
-      const orderType = 'limit'
-      let txid
-      if (market instanceof Market) {
-        txid = await mangoClient.placeSpotOrder(
-          mangoGroup,
-          mangoAccount,
-          mangoGroup.mangoCache,
-          market,
-          wallet,
-          order.side,
-          orderPrice,
-          order.size,
-          orderType
-        )
-      } else {
-        txid = await mangoClient.placePerpOrder(
-          mangoGroup,
-          mangoAccount,
-          mangoGroup.mangoCache,
-          market,
-          wallet,
           order.side,
           orderPrice,
           order.size,
@@ -376,9 +307,7 @@ const TVChartContainer = () => {
           `,
             callback: (res) => {
               if (res) {
-//                handleModifyOrder(order, market.account, updatedOrderPrice)
-                handleCancelOrder(order, market.account)
-                handlePlaceOrder(order, market.account, updatedOrderPrice)
+                handleModifyOrder(order, market.account, updatedOrderPrice)
               } else {
                 this.setPrice(currentOrderPrice)
               }

--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -13,7 +13,7 @@ import { useSortableData } from '../../hooks/useSortableData'
 import { Order, Market } from '@project-serum/serum/lib/market'
 import { PerpOrder, PerpMarket } from '@blockworks-foundation/mango-client'
 import { notify } from '../../utils/notifications'
-import { sleep } from '../../utils'
+import { sleep, formatUsdValue } from '../../utils'
 
 // This is a basic example of how to create a TV widget
 // You can add more feature such as storing charts in localStorage
@@ -51,7 +51,6 @@ const TVChartContainer = () => {
   const [lines, setLines] = useState(new Map())
   const [moveInProgress, toggleMoveInProgress] = useState(false)
 
-  
   // @ts-ignore
   const defaultProps: ChartContainerProps = {
     symbol: selectedMarketConfig.name,
@@ -142,8 +141,7 @@ const TVChartContainer = () => {
     tvWidgetRef.current = tvWidget
   }, [selectedMarketConfig, theme])
 
-  
-  const handleCancelOrder = async ( 
+  const handleCancelOrder = async (
     order: Order | PerpOrder,
     market: Market | PerpMarket
   ) => {
@@ -189,7 +187,6 @@ const TVChartContainer = () => {
       })
     }
   }
-
 
   const handleModifyOrder = async (
     order: Order | PerpOrder,
@@ -261,7 +258,6 @@ const TVChartContainer = () => {
     }
   }
 
-
   function getLine(order, market) {
     return tvWidgetRef.current
       .chart()
@@ -279,12 +275,12 @@ const TVChartContainer = () => {
           tvWidgetRef.current.showNoticeDialog({
             title: 'Order Price Outside Range',
             body:
-              `Your order price ($${updatedOrderPrice.toFixed(
-                2
+              `Your order price (${formatUsdValue(
+                updatedOrderPrice
               )}) is greater than 5% ${
                 order.side == 'buy' ? 'above' : 'below'
-              } the current market price ($${selectedMarketPrice.toFixed(
-                2
+              } the current market price (${formatUsdValue(
+                selectedMarketPrice
               )}). ` +
               ' indicating you might incur significant slippage. <p><p>Please use the trade input form if you wish to accept the potential slippage.',
             callback: () => {
@@ -295,15 +291,15 @@ const TVChartContainer = () => {
         } else {
           toggleMoveInProgress(true)
           tvWidgetRef.current.showConfirmDialog({
-            title: 'Change Order Price?',
+            title: 'Modify Your Order?',
             body: `Would you like to change your order from a 
            ${order.size} ${market.config.baseSymbol} ${
               order.side
-            } at $${currentOrderPrice} 
+            } at ${formatUsdValue(currentOrderPrice)} 
            to a 
-          ${order.size} ${market.config.baseSymbol} ${
+          ${order.size} ${market.config.baseSymbol} LIMIT ${
               order.side
-            } at $${updatedOrderPrice}? Current market price is ${selectedMarketPrice} 
+            } at ${formatUsdValue(updatedOrderPrice)}?
           `,
             callback: (res) => {
               if (res) {
@@ -323,7 +319,7 @@ const TVChartContainer = () => {
           body: `Would you like to cancel your order for 
        ${order.size} ${market.config.baseSymbol} ${
             order.side
-          } at $${order.price}  
+          } at ${formatUsdValue(order.price)}  
       `,
           callback: (res) => {
             if (res) {
@@ -333,9 +329,7 @@ const TVChartContainer = () => {
           },
         })
       })
-      .setText(
-        `${market.config.baseSymbol}`
-      )
+      .setText(`${market.config.baseSymbol} ${order.side.toUpperCase()}`)
       .setBodyBorderColor(order.side == 'buy' ? '#AFD803' : '#E54033')
       .setBodyBackgroundColor('#000000')
       .setBodyTextColor('#F2C94C')
@@ -352,7 +346,6 @@ const TVChartContainer = () => {
       .setPrice(order.price)
   }
 
-  
   useEffect(() => {
     if (!moveInProgress) {
       const tempLines = new Map()
@@ -363,7 +356,7 @@ const TVChartContainer = () => {
           })
         }
 
-        items.map(({order, market}, index) => {
+        items.map(({ order, market }) => {
           if (market.config.name == selectedMarketName) {
             tempLines.set(order.orderId.toString(), getLine(order, market))
           }
@@ -377,9 +370,6 @@ const TVChartContainer = () => {
     selectedMarketName,
     selectedMarketPrice,
   ])
-
-
-
 
   return <div id={defaultProps.containerId} className="tradingview-chart" />
 }

--- a/fix-husky.js
+++ b/fix-husky.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+// If Operating System is Windows, fix Husky for Yarn
+if (process.platform === 'win32') {
+  const huskyScript = fs.readFileSync('.git/hooks/husky.sh', {
+    encoding: 'utf-8',
+  });
+  const fixedHuskyScript = huskyScript.replace(
+    'run_command yarn run --silent;;',
+    'run_command npx --no-install;;'
+  );
+  fs.writeFileSync('.git/hooks/husky.sh', fixedHuskyScript);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,18 +993,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockworks-foundation/mango-client@git+https://github.com/blockworks-foundation/mango-client-v3.git":
-  version "3.0.12"
-  resolved "git+https://github.com/blockworks-foundation/mango-client-v3.git#5eeadbc3529af84db705951335cfe6592cd94683"
+"@blockworks-foundation/mango-client@^3.0.18":
+  version "3.0.18"
+  resolved "https://registry.yarnpkg.com/@blockworks-foundation/mango-client/-/mango-client-3.0.18.tgz#f665406365610fc9bbe3fecdd191fec9bd36df88"
+  integrity sha512-tcKrkp8R8fIpVnrcUWFeQLKQK/bRHDntHOIVwo1R3MbwCWcPrnt2Y68Ev4LEpBzQ1B8WXcHqwOXc2hS2Wx/bnA==
   dependencies:
     "@project-serum/serum" "0.13.55"
     "@project-serum/sol-wallet-adapter" "^0.2.0"
     "@solana/spl-token" "^0.1.6"
     "@solana/web3.js" "1.21.0"
+    axios "^0.21.1"
     big.js "^6.1.1"
     bigint-buffer "^1.1.5"
     bn.js "^5.1.0"
-    borsh "https://github.com/defactojob/borsh-js#field-mapper"
     buffer-layout "^1.2.1"
     yargs "^17.0.1"
 
@@ -2379,6 +2380,13 @@ available-typed-arrays@^1.0.2:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz#9e0ae84ecff20caae6a94a1c3bc39b955649b7a9"
   integrity sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -2590,15 +2598,6 @@ borsh@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.4.0.tgz#9dd6defe741627f1315eac2a73df61421f6ddb9f"
   integrity sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==
-  dependencies:
-    "@types/bn.js" "^4.11.5"
-    bn.js "^5.0.0"
-    bs58 "^4.0.0"
-    text-encoding-utf-8 "^1.0.2"
-
-"borsh@https://github.com/defactojob/borsh-js#field-mapper":
-  version "0.3.1"
-  resolved "https://github.com/defactojob/borsh-js#33a0d24af281112c0a48efb3fa503f3212443de9"
   dependencies:
     "@types/bn.js" "^4.11.5"
     bn.js "^5.0.0"
@@ -4296,6 +4295,11 @@ flatten@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
+
+follow-redirects@^1.14.0:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
+  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Added the ability to visualize orders on the TradingView widget.

Needs to be pulled in conjunction with mango-client-v3/tradingview-order-lines pull request which adds the ability to modify an order (cancel and replace) in a single transaction.