### PR TITLE
keep order size underneath order book overlay on hover during reposition

### DIFF
--- a/components/Orderbook.tsx
+++ b/components/Orderbook.tsx
@@ -322,7 +322,7 @@ export default function Orderbook({ depth = 8 }) {
                   </div>
                 </div>
                 <div className="flex">
-                  <div className="w-1/2">
+                  <div className="w-1/2 order-size">
                     {orderbookData?.bids.map(
                       ({
                         price,
@@ -350,7 +350,7 @@ export default function Orderbook({ depth = 8 }) {
                       )
                     )}
                   </div>
-                  <div className="w-1/2">
+                  <div className="w-1/2 order-size">
                     {orderbookData?.asks.map(
                       ({
                         price,

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
+@import 'order-book';
 /* Theme */
 
 :root {
@@ -270,38 +270,4 @@ input[type='number'] {
 .react-tel-input .selected-flag:focus,
 .react-tel-input .selected-flag.open {
   background-color: transparent !important;
-}
-
-/* orderbook flash */
-
-@keyframes highlight {
-  from {
-    background-color: var(--primary);
-  }
-  to {
-    background-color: transparent;
-  }
-}
-
-@-webkit-keyframes highlight {
-  from {
-    background-color: var(--primary);
-  }
-  to {
-    background-color: transparent;
-  }
-}
-@-moz-keyframes highlight {
-  from {
-    background-color: var(--primary);
-  }
-  to {
-    background-color: transparent;
-  }
-}
-
-.flash {
-  -moz-animation: highlight 0.5s ease 0s 1 alternate;
-  -webkit-animation: highlight 0.5s ease 0s 1 alternate;
-  animation: highlight 0.5s ease 0s 1 alternate;
 }

--- a/styles/order-book.css
+++ b/styles/order-book.css
@@ -1,0 +1,38 @@
+/* orderbook flash */
+
+@keyframes highlight {
+  from {
+    background-color: var(--primary);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+@-webkit-keyframes highlight {
+  from {
+    background-color: var(--primary);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+@-moz-keyframes highlight {
+  from {
+    background-color: var(--primary);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.flash {
+  -moz-animation: highlight 0.5s ease 0s 1 alternate;
+  -webkit-animation: highlight 0.5s ease 0s 1 alternate;
+  animation: highlight 0.5s ease 0s 1 alternate;
+}
+
+/* orderbook */
+.order-size {
+  z-index: 40;
+}


### PR DESCRIPTION
Issue: Per chat with TylerS, the order book size text remains on top of the overlay that appears on hover when the Order Book component can be repositioned. 

**Before**: 
<img width="492" alt="before" src="https://user-images.githubusercontent.com/4956122/132969741-d8d1eb40-7139-49fb-92c6-5d370b2255b3.png">

**After**:
<img width="627" alt="after" src="https://user-images.githubusercontent.com/4956122/132969748-c689c79c-7206-4a8e-a1a0-71739502b666.png">

Notes: You don't typically need to have such high z-index values. It can get overly complex if there are multiple elements competing for the top spot and you're guessing where the top is. I need to dig into the frameworks being used and why it was set to 50. For now, I've reduced the z-index to 40 and the issue appears resolved. Also, I've created a separate CSS file for the order-book since I made these changes for that component, because as the application grows you don't want one CSS file with all the styles in the same file. Bloat will become untenable. Best practice is to keep them in specific files and import them into one main CSS file.
