### PR TITLE
pre-fill spot balance

### DIFF
--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -5,7 +5,10 @@ import Button, { LinkButton } from '../components/Button'
 import { notify } from '../utils/notifications'
 import { ArrowSmDownIcon, ExclamationIcon } from '@heroicons/react/outline'
 import { Market } from '@project-serum/serum'
-import { getTokenBySymbol } from '@blockworks-foundation/mango-client'
+import {
+  getMarketIndexBySymbol,
+  getTokenBySymbol,
+} from '@blockworks-foundation/mango-client'
 import { useState } from 'react'
 import Loading from './Loading'
 import { useViewport } from '../hooks/useViewport'
@@ -39,9 +42,41 @@ const BalancesTable = ({ showZeroBalances = false }) => {
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const mangoGroupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
   const mangoClient = useMangoStore((s) => s.connection.client)
+  const selectedMarket = useMangoStore((s) => s.selectedMarket.current)
+  const marketConfig = useMangoStore((s) => s.selectedMarket.config)
+  const setMangoStore = useMangoStore((s) => s.set)
+  const price = useMangoStore((s) => s.tradeForm.price)
+  const mangoGroupCache = useMangoStore((s) => s.selectedMangoGroup.cache)
   const { width } = useViewport()
   const [submitting, setSubmitting] = useState(false)
   const isMobile = width ? width < breakpoints.md : false
+
+  const handleSizeClick = (size, symbol) => {
+    const step = selectedMarket.minOrderSize
+    const marketIndex = getMarketIndexBySymbol(
+      mangoGroupConfig,
+      marketConfig.baseSymbol
+    )
+    const priceOrDefault = price
+      ? price
+      : mangoGroup.getPrice(marketIndex, mangoGroupCache).toNumber()
+    if (symbol === 'USDC') {
+      const baseSize = Math.floor(size / priceOrDefault / step) * step
+      setMangoStore((state) => {
+        state.tradeForm.baseSize = baseSize
+        state.tradeForm.quoteSize = (baseSize * priceOrDefault).toFixed(2)
+        state.tradeForm.side = 'buy'
+      })
+    } else {
+      const roundedSize = Math.round(size / step) * step
+      const quoteSize = roundedSize * priceOrDefault
+      setMangoStore((state) => {
+        state.tradeForm.baseSize = roundedSize
+        state.tradeForm.quoteSize = quoteSize.toFixed(2)
+        state.tradeForm.side = 'sell'
+      })
+    }
+  }
 
   const handleOpenDepositModal = useCallback((symbol) => {
     setActionSymbol(symbol)
@@ -312,7 +347,26 @@ const BalancesTable = ({ showZeroBalances = false }) => {
                       <Td>{balance.borrows.toFixed()}</Td>
                       <Td>{balance.orders}</Td>
                       <Td>{balance.unsettled}</Td>
-                      <Td>{balance.net.toFixed()}</Td>
+                      <Td>
+                        {marketConfig.kind === 'spot' &&
+                        marketConfig.name.includes(balance.symbol) &&
+                        selectedMarket ? (
+                          <span
+                            className={
+                              balance.net.toNumber() > 0
+                                ? 'cursor-pointer underline hover:no-underline'
+                                : ''
+                            }
+                            onClick={() =>
+                              handleSizeClick(balance.net, balance.symbol)
+                            }
+                          >
+                            {balance.net.toFixed()}
+                          </span>
+                        ) : (
+                          balance.net.toFixed()
+                        )}
+                      </Td>
                       <Td>{formatUsdValue(balance.value)}</Td>
                       <Td>
                         <span className="text-th-green">

--- a/components/MarketPosition.tsx
+++ b/components/MarketPosition.tsx
@@ -84,6 +84,7 @@ export default function MarketPosition() {
   const connected = useMangoStore((s) => s.wallet.connected)
   const isLoading = useMangoStore((s) => s.selectedMangoAccount.initialLoad)
   const setMangoStore = useMangoStore((s) => s.set)
+  const price = useMangoStore((s) => s.tradeForm.price)
   const baseSymbol = marketConfig.baseSymbol
   const marketName = marketConfig.name
   const tradeHistory = useTradeHistory()
@@ -109,9 +110,18 @@ export default function MarketPosition() {
     )
   }
 
-  const handleSizeClick = (size) => {
+  const handleSizeClick = (size, side) => {
+    const step = selectedMarket.minOrderSize
+
+    const priceOrDefault = price
+      ? price
+      : mangoGroup.getPrice(marketIndex, mangoGroupCache).toNumber()
+    const roundedSize = Math.round(size / step) * step
+    const quoteSize = roundedSize * priceOrDefault
     setMangoStore((state) => {
-      state.tradeForm.baseSize = size
+      state.tradeForm.baseSize = roundedSize
+      state.tradeForm.quoteSize = quoteSize.toFixed(2)
+      state.tradeForm.side = side === 'buy' ? 'sell' : 'buy'
     })
   }
 
@@ -126,6 +136,8 @@ export default function MarketPosition() {
     })
   }
 
+  const side = perpAccount.basePosition.gt(ZERO_BN) ? 'long' : 'short'
+
   if (!mangoGroup || !selectedMarket) return null
 
   return selectedMarket instanceof PerpMarket ? (
@@ -139,9 +151,7 @@ export default function MarketPosition() {
           {isLoading ? (
             <DataLoader />
           ) : perpAccount && !perpAccount.basePosition.eq(ZERO_BN) ? (
-            <SideBadge
-              side={perpAccount.basePosition.gt(ZERO_BN) ? 'long' : 'short'}
-            />
+            <SideBadge side={side} />
           ) : (
             '--'
           )}
@@ -163,7 +173,8 @@ export default function MarketPosition() {
                   handleSizeClick(
                     Math.abs(
                       selectedMarket.baseLotsToNumber(perpAccount.basePosition)
-                    )
+                    ),
+                    side === 'long' ? 'buy' : 'sell'
                   )
                 }
               >

--- a/components/MarketPosition.tsx
+++ b/components/MarketPosition.tsx
@@ -136,7 +136,11 @@ export default function MarketPosition() {
     })
   }
 
-  const side = perpAccount.basePosition.gt(ZERO_BN) ? 'long' : 'short'
+  const side = perpAccount
+    ? perpAccount.basePosition.gt(ZERO_BN)
+      ? 'long'
+      : 'short'
+    : null
 
   if (!mangoGroup || !selectedMarket) return null
 


### PR DESCRIPTION
Added:

• Click balances to populate trade form
• Populate both base and quote
• Only enable on the trade page for the associated asset/market

There's a bit of duplicate code (handleSizeClick). Was thinking about a hook to manage trade form state but a re-factor of the trade form is imminent so have copied the function for now. Let me know if you want this changed.