### PR TITLE
Fix calculateTradePrice function

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -108,7 +108,11 @@ export function calculateTradePrice(
   if (tradeType === 'Market') {
     return calculateMarketPrice(orderBook, baseSize, side)
   } else if (TRIGGER_ORDER_TYPES.includes(tradeType)) {
-    return Number(triggerPrice)
+    if( tradeType === 'Take Profit Limit' || tradeType === 'Stop Limit' ) {
+      return Number(price)
+    } else {
+      return Number(triggerPrice)
+    }
   }
   return Number(price)
 }


### PR DESCRIPTION
The current calculateTradePrice function used in the AdvancedOrderForm doesn't incorporate the specified limit price of a Take Profit Limit or Stop Limit. For example if you enter a Take Profit Limit order with a Trigger Price of $60,000 and set the limit price to $58,000, the limit price is ignored by calculateTradePrice due to the if condition statement and sets the limit price at the Trigger Price.

![image](https://user-images.githubusercontent.com/47860274/137374826-bf6e75aa-f63a-481c-96d4-37a07629c8f3.png)

Proposed fix checks if the advanced order type is a limit order and uses the price limit the user specified.

![image](https://user-images.githubusercontent.com/47860274/137375662-bf04760a-243b-421b-953f-bc887aa38b2b.png)


