### PR TITLE
Toggle button for Order Line Visibility

### DIFF
--- a/components/TradingView/index.tsx
+++ b/components/TradingView/index.tsx
@@ -153,7 +153,7 @@ const TVChartContainer = () => {
       button.textContent = 'OL'
       button.style.color = theme === 'Dark' || theme === 'Mango' ? 'rgb(242, 201, 76)' : 'rgb(255, 156, 36)'
       button.setAttribute('title', 'Toggle order line visibility')
-      button.addEventListener('click', function (e) {
+      button.addEventListener('click', function () {
         toggleShowOrderLines((showOrderLines) => !showOrderLines)
         if (button.style.color === 'rgb(255, 156, 36)' || button.style.color === 'rgb(242, 201, 76)') {
           button.style.color = theme === 'Dark' || theme === 'Mango' ? 'rgb(138, 138, 138)' : 'rgb(138, 138, 138)'


### PR DESCRIPTION
Allow users to toggle order line visibility on and off.  Should be useful if you have a lot of orders on the books.

https://user-images.githubusercontent.com/47860274/139183688-7c1533ae-4260-49dc-b85a-8fc25e3ed057.mp4


