### PR TITLE
disable trade button and show warning when user has no SOL

### DIFF
--- a/components/trade_form/AdvancedTradeForm.tsx
+++ b/components/trade_form/AdvancedTradeForm.tsx
@@ -49,6 +49,7 @@ export default function AdvancedTradeForm({
   const actions = useMangoStore((s) => s.actions)
   const groupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
   const marketConfig = useMangoStore((s) => s.selectedMarket.config)
+  const walletTokens = useMangoStore((s) => s.wallet.tokens)
   const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
   const mangoClient = useMangoStore((s) => s.connection.client)
   const market = useMangoStore((s) => s.selectedMarket.current)
@@ -56,6 +57,7 @@ export default function AdvancedTradeForm({
   const [reduceOnly, setReduceOnly] = useState(false)
   const [spotMargin, setSpotMargin] = useState(true)
   const [positionSizePercent, setPositionSizePercent] = useState('')
+  const [insufficientSol, setinsufficientSol] = useState(false)
   const { takerFee, makerFee } = useFees()
   const { totalMsrm } = useSrmAccount()
 
@@ -107,6 +109,11 @@ export default function AdvancedTradeForm({
       ),
     []
   )
+
+  useEffect(() => {
+    const walletSol = walletTokens.find((a) => a.config.symbol === 'SOL')
+    walletSol ? setinsufficientSol(walletSol.uiBalance < 0.01) : null
+  }, [walletTokens])
 
   useEffect(() => {
     if (tradeType === 'Market') {
@@ -625,7 +632,8 @@ export default function AdvancedTradeForm({
     !connected ||
     submitting ||
     !mangoAccount ||
-    sizeTooLarge
+    sizeTooLarge ||
+    insufficientSol
 
   const canTrade = ipAllowed || (market instanceof Market && spotAllowed)
 
@@ -892,6 +900,12 @@ export default function AdvancedTradeForm({
               </div>
             )}
           </div>
+          {insufficientSol ? (
+            <div className="tiny-text text-center text-th-red mt-1 -mb-3">
+              You must leave enough SOL in your wallet to pay for the
+              transaction
+            </div>
+          ) : null}
           <div className="flex flex-col md:flex-row text-xs text-th-fgd-4 px-6 mt-2.5 items-center justify-center">
             <div>Maker fee: {(makerFee * 100).toFixed(2)}% </div>
             <span className="hidden md:block md:px-1">|</span>

--- a/components/trade_form/SimpleTradeForm.tsx
+++ b/components/trade_form/SimpleTradeForm.tsx
@@ -32,6 +32,7 @@ export default function SimpleTradeForm({ initLeverage }) {
   const actions = useMangoStore((s) => s.actions)
   const groupConfig = useMangoStore((s) => s.selectedMangoGroup.config)
   const marketConfig = useMangoStore((s) => s.selectedMarket.config)
+  const walletTokens = useMangoStore((s) => s.wallet.tokens)
   const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
   const mangoGroup = useMangoStore((s) => s.selectedMangoGroup.current)
   const mangoClient = useMangoStore((s) => s.connection.client)
@@ -53,9 +54,11 @@ export default function SimpleTradeForm({ initLeverage }) {
   const [stopSizePercent, setStopSizePercent] = useState('5%')
   const [reduceOnly, setReduceOnly] = useState(false)
   const [spotMargin, setSpotMargin] = useState(false)
+  const [insufficientSol, setinsufficientSol] = useState(false)
 
   const orderBookRef = useRef(useMangoStore.getState().selectedMarket.orderBook)
   const orderbook = orderBookRef.current
+
   useEffect(
     () =>
       useMangoStore.subscribe(
@@ -65,6 +68,11 @@ export default function SimpleTradeForm({ initLeverage }) {
       ),
     []
   )
+
+  useEffect(() => {
+    const walletSol = walletTokens.find((a) => a.config.symbol === 'SOL')
+    walletSol ? setinsufficientSol(walletSol.uiBalance < 0.01) : null
+  }, [walletTokens])
 
   useEffect(() => {
     if (tradeType !== 'Market' && tradeType !== 'Limit') {
@@ -415,7 +423,8 @@ export default function SimpleTradeForm({ initLeverage }) {
     !baseSize ||
     !connected ||
     submitting ||
-    !mangoAccount
+    !mangoAccount ||
+    insufficientSol
 
   const hideProfitStop =
     (side === 'sell' && baseSize === roundedDeposits) ||
@@ -720,6 +729,11 @@ export default function SimpleTradeForm({ initLeverage }) {
             </div>
           )}
         </div>
+        {insufficientSol ? (
+          <div className="tiny-text text-center text-th-red mt-1 -mb-3">
+            You must leave enough SOL in your wallet to pay for the transaction
+          </div>
+        ) : null}
         <div className="col-span-12 flex pt-2 text-xs text-th-fgd-4">
           <MarketFee />
         </div>


### PR DESCRIPTION
Displays a warning under and disables the trade button when a user doesn't have enough SOL in the wallet to cover the transaction cost