### PR TITLE
Mango Heroes NFT Integration

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: ['https://mangoheroes.com']


### PR DESCRIPTION
### Purpose for pull request
This pull request will be integrating the Mango Heroes NFT collection as profile pictures in Mango Markets.

### Feature list
- Mango Heroes will be displayed as a replacement of the default avatar image
- Users can change their avatar if they have multiple avatars to choose from
- Currently selected avatar is kept in the store to be used anywhere else in the application

### How is it implemented?
We scan the connected wallet for any NFTs and then compare their update authority to the MH mint address to retrieve list of MH NFTs. The profile image will be retrieved using Metaplex code stored in `utils/metaplex` folder.

### Translations needed
- Okay
- Change Avatar
- Avatar updated successfully

### Images
![image](https://user-images.githubusercontent.com/8518902/141338658-91a79b1f-35d8-4a7d-9bee-06d45d8b0f77.png)
![image](https://user-images.githubusercontent.com/8518902/141338703-75e0a3f7-490f-48c2-a6ba-4cd4ba9b3260.png)
![image](https://user-images.githubusercontent.com/8518902/141338886-2364e446-574c-4a45-a30f-aca6e091b68f.png)