### PR TITLE
backwards compatibility to pubkey object

### DIFF
--- a/utils/wallet-adapters/solflare-extension.ts
+++ b/utils/wallet-adapters/solflare-extension.ts
@@ -68,7 +68,13 @@ export class SolflareExtensionWalletAdapter
   }
 
   get publicKey() {
-    return this._provider?.publicKey || DEFAULT_PUBLIC_KEY
+    const instance = this._provider?.publicKey
+    
+    if (instance) {
+      return new PublicKey(instance.toString());
+    }
+
+    return DEFAULT_PUBLIC_KEY;
   }
 
   async signTransaction(transaction: Transaction) {


### PR DESCRIPTION
Some legacy clients have only the toString method supported so this is the fix to make the adapter backwards compatible