### PR TITLE
show refresh button when no account

### DIFF
--- a/components/ManualRefresh.tsx
+++ b/components/ManualRefresh.tsx
@@ -9,12 +9,15 @@ const ManualRefresh = ({ className = '' }) => {
   const { t } = useTranslation('common')
   const [spin, setSpin] = useState(false)
   const actions = useMangoStore((s) => s.actions)
+  const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
 
   const handleRefreshData = async () => {
     setSpin(true)
     await actions.fetchMangoGroup()
-    await actions.reloadMangoAccount()
-    actions.fetchTradeHistory()
+    if (mangoAccount) {
+      await actions.reloadMangoAccount()
+      actions.fetchTradeHistory()
+    }
   }
 
   useEffect(() => {

--- a/components/MarketDetails.tsx
+++ b/components/MarketDetails.tsx
@@ -60,7 +60,6 @@ const MarketDetails = () => {
   const isPerpMarket = marketConfig.kind === 'perp'
 
   const previousMarketName: string = usePrevious(selectedMarketName)
-  const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
   const connected = useMangoStore((s) => s.wallet.connected)
   const { width } = useViewport()
   const isMobile = width ? width < breakpoints.sm : false
@@ -264,7 +263,7 @@ const MarketDetails = () => {
           </div>
         ) : null}
         <div className="ml-2" id="data-refresh-tip">
-          {!isMobile && connected && mangoAccount ? <ManualRefresh /> : null}
+          {!isMobile && connected ? <ManualRefresh /> : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
We have a tip for the manual refresh button but it is hidden if the user has no account (likely if they are going through the intro tour).

PR changes it to show even with no account but only update the account functions if the user has an account.