### PR TITLE
Update Precision Utils Information

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -158,6 +158,9 @@ export const tokenPrecision = {
   COPE: 2,
   FTT: 3,
   ADA: 2,
+  MSOL: 2,
+  BNB: 3,
+  AVAX: 2,
   USDC: 2,
   USDT: 2,
 }
@@ -172,6 +175,8 @@ export const perpContractPrecision = {
   RAY: 1,
   FTT: 1,
   ADA: 0,
+  BNB: 3,
+  AVAX: 2,
 }
 
 const tokenPricePrecision = {
@@ -184,6 +189,9 @@ const tokenPricePrecision = {
   COPE: 3,
   FTT: 3,
   ADA: 4,
+  MSOL: 2,
+  BNB: 1,
+  AVAX: 2,
   USDC: 2,
   USDT: 2,
 }


### PR DESCRIPTION
UI precision information doesn't currently include MSOL, BNB, or AVAX.