### PR TITLE
Add keep-break class to solve issues with CJK display

### DIFF
--- a/components/AccountsModal.tsx
+++ b/components/AccountsModal.tsx
@@ -89,7 +89,7 @@ const AccountsModal: FunctionComponent<AccountsModalProps> = ({
               >
                 <div className="flex items-center">
                   <PlusCircleIcon className="h-5 w-5 mr-1.5" />
-                  {t('new')}
+                  {t('new-account')}
                 </div>
               </Button>
             </div>

--- a/components/CreateAlertModal.tsx
+++ b/components/CreateAlertModal.tsx
@@ -106,7 +106,7 @@ const CreateAlertModal: FunctionComponent<CreateAlertModalProps> = ({
                   >
                     <div className="flex items-center">
                       <PlusCircleIcon className="h-4 w-4 mr-1.5" />
-                      {t('new')}
+                      {t('alerts:new-alert')}
                     </div>
                   </Button>
                 </div>

--- a/components/TradeHistoryTable.tsx
+++ b/components/TradeHistoryTable.tsx
@@ -273,7 +273,7 @@ const TradeHistoryTable = ({ numTrades }: { numTrades?: number }) => {
                                 )
                               : t('recent')}
                           </Td>
-                          <Td className="!py-2 w-[0.1%]">
+                          <Td className="!py-2 w-[0.1%] keep-break">
                             {trade.marketName.includes('PERP') ? (
                               <a
                                 className="text-th-fgd-4 underline text-xs underline-offset-4"

--- a/styles/index.css
+++ b/styles/index.css
@@ -517,3 +517,8 @@ body::-webkit-scrollbar-corner {
 .fadein-floating-element {
   animation: fadein 1s linear;
 }
+
+/* CJK characters */
+.keep-break {
+  word-break: keep-all;
+}


### PR DESCRIPTION
Currently the UI has some awkward line breaking when displaying CJK characters. I've added the keep-break class (not included in default tailwind) to resolve this.
Also cleared up some localization errors caused by the word "New"

![image](https://user-images.githubusercontent.com/4095852/155853388-2147ab10-93d7-450f-ac3d-b11b0ef93798.png)
