### PR TITLE
fix typo in orders table

### DIFF
--- a/components/OpenOrdersTable.tsx
+++ b/components/OpenOrdersTable.tsx
@@ -64,7 +64,7 @@ const DesktopTable = ({
       <thead>
         <TrHead>
           <Th>{t('market')}</Th>
-          <Th>{t('size')}</Th>
+          <Th>{t('side')}</Th>
           <Th>{t('size')}</Th>
           <Th>{t('price')}</Th>
           <Th>{t('value')}</Th>


### PR DESCRIPTION
Hi team, just found a tiny typo. It should be `side` instead of `size`:

<img width="435" alt="image" src="https://user-images.githubusercontent.com/6276527/155881434-2fa4caa0-5e42-4a3a-b409-62fd5fb9270c.png">
