### PR TITLE
Chart Line Updates & Toggle Settings

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -30,6 +30,7 @@ export const NODE_URL_KEY = 'node-url-key-0.5'
 export const DEFAULT_MARKET_KEY = 'defaultMarket-0.3'
 export const ORDERBOOK_FLASH_KEY = 'showOrderbookFlash'
 export const DEFAULT_SPOT_MARGIN_KEY = 'defaultSpotMargin'
+export const DEFAULT_ORDER_LINES_KEY = 'showOrderLines'
 export const initialMarket = {
   base: 'SOL',
   kind: 'perp',
@@ -57,6 +58,11 @@ const SettingsModal = ({ isOpen, onClose }) => {
   const [defaultSpotMargin, setDefaultSpotMargin] = useLocalStorageState(
     DEFAULT_SPOT_MARGIN_KEY,
     false
+  )
+
+  const [showOrderLines, setShowOrderLines] = useLocalStorageState(
+    DEFAULT_ORDER_LINES_KEY,
+    true
   )
 
   const rpcEndpoint =
@@ -110,6 +116,13 @@ const SettingsModal = ({ isOpen, onClose }) => {
             <Switch
               checked={defaultSpotMargin}
               onChange={(checked) => setDefaultSpotMargin(checked)}
+            />
+          </div>
+          <div className="border-t border-th-bkg-4 flex items-center justify-between py-3 text-th-fgd-1">
+            <span>{t('orderline-visible')}</span>
+            <Switch
+              checked={showOrderLines}
+              onChange={(checked) => setShowOrderLines(checked)}
             />
           </div>
         </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -258,6 +258,7 @@
   "order-error": "Error placing order",
   "orderbook": "Orderbook",
   "orderbook-animation": "Orderbook Animation",
+  "orderline-visible": "Show order lines on chart",
   "orders": "Orders",
   "performance": "Performance",
   "performance-insights": "Performance Insights",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -254,6 +254,7 @@
   "order-error": "Error al realizar el pedido",
   "orderbook": "Libro de órdenes",
   "orderbook-animation": "Animación del libro de ordenes",
+  "orderline-visible": "Mostrar líneas de orden en el gráfico",
   "orders": "Órdenes",
   "performance": "Performance",
   "performance-insights": "Performance Insights",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -254,6 +254,7 @@
     "order-error": "下订单出错了",
     "orderbook": "订单簿",
     "orderbook-animation": "订单动画",
+    "orderline-visible": "在图表上显示订单线",
     "orders": "订单",
     "performance": "表现",
     "performance-insights": "表现分析",

--- a/public/locales/zh_tw/common.json
+++ b/public/locales/zh_tw/common.json
@@ -254,6 +254,7 @@
   "order-error": "下訂單出錯了",
   "orderbook": "掛單簿",
   "orderbook-animation": "訂單動畫",
+  "orderline-visible": "在圖表上顯示訂單線",
   "orders": "訂單",
   "performance": "表現",
   "performance-insights": "表現分析",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,15 +2754,10 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bn.js@5.1.3, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.1.0, bn.js@^5.1.2, bn.js@~5.2.0:
+bn.js@5.1.3, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.1.0, bn.js@^5.1.2, bn.js@^5.2.0, bn.js@~5.2.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
-
-bn.js@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
-  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 boolbase@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Average entry line for perps have been added to the chart as well as the ability to toggle the lines off and on as a local setting so that the user doesn't have to do it each time they load the site. The default onChartReady action has also been updated to delete lines but not redraw them as this may have been causing the issue Klossie came across when viewing other pubkeys.

![image](https://user-images.githubusercontent.com/47860274/156901576-77752547-6f8f-4d62-9708-9a0b1e885626.png)

![image](https://user-images.githubusercontent.com/47860274/156901548-9bd4eb58-67da-4152-a6bd-508bbcceabbb.png)

