### PR TITLE
Handle input of invalid pairs

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -102,6 +102,11 @@ const PerpMarket = () => {
         groupConfig,
         marketBaseSymbol.toUpperCase()
       )
+
+      if (!newMarket?.baseSymbol) {
+        router.push('/')
+        return
+      }
     }
 
     if (name && mangoGroup) {


### PR DESCRIPTION
### Scenario

I accidentally made a typo in the url when trying to redirect to another market and faced this unfriendly error:

![image](https://user-images.githubusercontent.com/8385226/158622067-a9a40123-a09f-404f-bbcc-58deb635a344.png)

My url was: `http://.../?name=ETC-PERP`, this error happens locally and on prod.

### Solution

I've tracked where the state gets updated and when there is missing data I've suggested to redirect to home, thus forcing to fallback to the default market/pair.

WDYT?