### PR TITLE
Adds MangoAccountSearch to /account

### DIFF
--- a/components/account_page/MangoAccountSearch.tsx
+++ b/components/account_page/MangoAccountSearch.tsx
@@ -1,0 +1,60 @@
+import { PublicKey } from '@solana/web3.js'
+import Button from 'components/Button'
+import Input from 'components/Input'
+import { useRouter } from 'next/router'
+import React, { useState } from 'react'
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
+
+export const MangoAccountSearch = () => {
+  const router = useRouter()
+  const [value, setValue] = useState('')
+  const [isInvalid, setIsInvalid] = useState(false)
+
+  const validatePubKey = (key: string) => {
+    try {
+      const pubkey = new PublicKey(key)
+      return PublicKey.isOnCurve(pubkey.toBuffer())
+    } catch (e) {
+      return false
+    }
+  }
+
+  const onClickSearch = () => {
+    const isValid = validatePubKey(value)
+
+    if (isValid) {
+      const route = `/account?pubkey=${value}`
+      setValue('')
+      router.push(route)
+    } else {
+      setIsInvalid(true)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center rounded-lg px-4 pb-2 text-th-fgd-1 md:mt-6">
+      <h2 className="mb-1 text-base">Search by Mango Account</h2>
+      <p className="mb-2 text-center">
+        Enter a Mango account address to show account details
+      </p>
+      <div className="w-[400px] p-1">
+        <Input
+          type="text"
+          error={isInvalid}
+          placeholder="Address"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </div>
+      {isInvalid && (
+        <div className="flex items-center pt-1.5 text-th-red">
+          <ExclamationCircleIcon className="mr-1.5 h-4 w-4" />
+          The address is invalid
+        </div>
+      )}
+      <div className="pt-3 pb-2">
+        <Button onClick={onClickSearch}>Search</Button>
+      </div>
+    </div>
+  )
+}

--- a/components/account_page/MangoAccountSearch.tsx
+++ b/components/account_page/MangoAccountSearch.tsx
@@ -32,12 +32,12 @@ export const MangoAccountSearch = () => {
   }
 
   return (
-    <div className="flex flex-col items-center rounded-lg px-4 pb-2 text-th-fgd-1 md:mt-6">
+    <div className="flex flex-col items-center rounded-lg px-4 text-th-fgd-1">
       <h2 className="mb-1 text-base">Search by Mango Account</h2>
       <p className="mb-2 text-center">
         Enter a Mango account address to show account details
       </p>
-      <div className="w-[400px] p-1">
+      <div className="w-[350px] p-1 md:w-[400px]">
         <Input
           type="text"
           error={isInvalid}

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -55,6 +55,7 @@ import CreateAlertModal from '../components/CreateAlertModal'
 import { copyToClipboard } from '../utils'
 import DelegateModal from '../components/DelegateModal'
 import { Menu, Transition } from '@headlessui/react'
+import { MangoAccountSearch } from 'components/account_page/MangoAccountSearch'
 
 export async function getStaticProps({ locale }) {
   return {
@@ -444,6 +445,11 @@ export default function Account() {
             />
           )}
         </div>
+        {!connected && (
+          <div className="mt-6 md:mt-3 md:rounded-lg md:bg-th-bkg-2 md:p-6">
+            <MangoAccountSearch />
+          </div>
+        )}
       </PageBodyContainer>
       {showAccountsModal ? (
         <AccountsModal


### PR DESCRIPTION
- Adds component `MangoAccountSearch` which adds an input for looking up a mango account address. This component is only visible if the user is not connected.

- Desktop:
<img width="1157" alt="Screen Shot 2022-03-24 at 6 07 40 PM" src="https://user-images.githubusercontent.com/21182806/159971999-52a7d3d9-a83c-417a-9d8a-b0830e54d529.png">

- Mobile:
<img width="428" alt="Screen Shot 2022-03-24 at 6 08 57 PM" src="https://user-images.githubusercontent.com/21182806/159972019-3b1ab6de-cc7e-4ff4-b8c9-026902f9a742.png">


 