### PR TITLE
Removes z-index on Jupiter form

### DIFF
--- a/components/JupiterForm.tsx
+++ b/components/JupiterForm.tsx
@@ -352,7 +352,7 @@ const JupiterForm: FunctionComponent = () => {
       <div className="col-span-12 xl:col-span-10 xl:col-start-2 ">
         <div className="flex flex-col md:flex-row md:space-x-6">
           <div className="w-full md:w-1/2  lg:w-1/3">
-            <div className="relative z-10">
+            <div className="relative">
               {connected &&
               walletTokensWithInfos.length &&
               walletTokenPrices &&


### PR DESCRIPTION
- Fix for `More` dropdown going behind Swap form:
<img width="359" alt="Screen Shot 2022-03-24 at 7 42 16 PM" src="https://user-images.githubusercontent.com/21182806/159989197-4af32246-8c59-4c84-90d3-f98a4ce4a00f.png">

