### PR TITLE
sort performance data explicitly

### DIFF
--- a/components/account_page/AccountOverview.tsx
+++ b/components/account_page/AccountOverview.tsx
@@ -35,14 +35,13 @@ export const fetchHourlyPerformanceStats = async (
       .format('YYYY-MM-DD')}`
   )
   const parsedResponse = await response.json()
-  const entries: any = Object.entries(parsedResponse)
+  const entries: any = Object.entries(parsedResponse).sort((a,b) => b[0].localeCompare(a[0]))
 
   const stats = entries
     .map(([key, value]) => {
       return { ...value, time: key }
     })
     .filter((x) => x)
-    .reverse()
 
   return stats
 }

--- a/components/account_page/AccountPerformance.tsx
+++ b/components/account_page/AccountPerformance.tsx
@@ -74,14 +74,13 @@ const AccountPerformance = () => {
         `https://mango-transaction-log.herokuapp.com/v3/stats/account-performance?mango-account=${mangoAccountPk}`
       )
       const parsedResponse = await response.json()
-      const entries: any = Object.entries(parsedResponse)
+      const entries: any = Object.entries(parsedResponse).sort((a,b) => b[0].localeCompare(a[0]))
 
       const stats = entries
         .map(([key, value]) => {
           return { ...value, time: key }
         })
         .filter((x) => x)
-        .reverse()
 
       setLoading(false)
       setHourlyPerformanceStats(stats)


### PR DESCRIPTION
I am looking to switch from using flask to fast-api for the api server.
During my testing I found that flask is silently sorting the json response on keys -> so switching to fast-api would reverse the order.
So this change would ensure the correct ordering using both flask and fast-api.
The sorting could be removed after the switch over.