### PR TITLE
Show fewer decimals for large balances

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
       - run: yarn install --frozen-lockfile
       - run: yarn type-check
       - run: yarn lint

--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -148,6 +148,24 @@ const BalancesTable = ({
 
   const unsettledBalances = balances.filter((bal) => bal.unsettled > 0)
 
+  const trimDecimals = useCallback((num: string) => {
+    if (parseInt(num) === 0) {
+      return '0'
+    }
+    // Trim the decimals depending on the length of the whole number
+    const splitNum = num.split('.')
+    if (splitNum.length > 1) {
+      const wholeNum = splitNum[0]
+      const decimals = splitNum[1]
+      if (wholeNum.length > 8) {
+        return `${wholeNum}.${decimals.substring(0, 2)}`
+      } else if (wholeNum.length > 3) {
+        return `${wholeNum}.${decimals.substring(0, 3)}`
+      }
+    }
+    return num
+  }, [])
+
   return (
     <div className={`flex flex-col pb-2 sm:pb-4`}>
       {unsettledBalances.length > 0 ? (
@@ -361,7 +379,6 @@ const BalancesTable = ({
                 </thead>
                 <tbody>
                   {items.map((balance, index) => {
-                    console.log('balance', balance)
                     if (!balance) {
                       return null
                     }
@@ -397,8 +414,16 @@ const BalancesTable = ({
                             )}
                           </div>
                         </Td>
-                        <Td>{balance.deposits.toFormat(balance.decimals)}</Td>
-                        <Td>{balance.borrows.toFormat(balance.decimals)}</Td>
+                        <Td>
+                          {trimDecimals(
+                            balance.deposits.toFormat(balance.decimals)
+                          )}
+                        </Td>
+                        <Td>
+                          {trimDecimals(
+                            balance.borrows.toFormat(balance.decimals)
+                          )}
+                        </Td>
                         <Td>{balance.orders}</Td>
                         <Td>{balance.unsettled}</Td>
                         <Td>
@@ -416,10 +441,12 @@ const BalancesTable = ({
                                 handleSizeClick(balance.net, balance.symbol)
                               }
                             >
-                              {balance.net.toFormat(balance.decimals)}
+                              {trimDecimals(
+                                balance.net.toFormat(balance.decimals)
+                              )}
                             </span>
                           ) : (
-                            balance.net.toFormat(balance.decimals)
+                            trimDecimals(balance.net.toFormat(balance.decimals))
                           )}
                         </Td>
                         <Td>{formatUsdValue(balance.value.toNumber())}</Td>

--- a/components/BalancesTable.tsx
+++ b/components/BalancesTable.tsx
@@ -149,7 +149,7 @@ const BalancesTable = ({
   const unsettledBalances = balances.filter((bal) => bal.unsettled > 0)
 
   const trimDecimals = useCallback((num: string) => {
-    if (parseInt(num) === 0) {
+    if (parseFloat(num) === 0) {
       return '0'
     }
     // Trim the decimals depending on the length of the whole number


### PR DESCRIPTION
- Fix for Show fewer decimals for large balances: https://trello.com/c/C2XKsREa/114-show-fewer-decimals-for-large-balances
- If the balance is greater than or equal to 1,000,000 show 2 decimals or If the balance is greater than or equal to 1,000 show 3 decimals
- Also displays `0` for floats that are equal to `0`

## Before
<img width="1246" alt="Screen Shot 2022-03-25 at 2 13 05 PM" src="https://user-images.githubusercontent.com/21182806/160127681-146cd067-93e5-4fd5-8116-4a212648a1b3.png">

## After
<img width="1288" alt="Screen Shot 2022-03-25 at 2 14 57 PM" src="https://user-images.githubusercontent.com/21182806/160127724-fee6e903-acb3-4f0e-b981-55fff9a96a9b.png">

