### PR TITLE
Small QA changes

### DIFF
--- a/components/trade_form/AdvancedTradeForm.tsx
+++ b/components/trade_form/AdvancedTradeForm.tsx
@@ -808,7 +808,9 @@ export default function AdvancedTradeForm({
                 onChange={(e) => onSetPrice(e.target.value)}
                 value={postOnlySlide ? '' : price}
                 disabled={isMarketOrder || postOnlySlide}
-                placeholder={tradeType === 'Market' ? markPrice : null}
+                placeholder={
+                  tradeType === 'Market' && !postOnlySlide ? markPrice : ''
+                }
                 prefix={
                   <>
                     {!postOnlySlide && (

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -296,7 +296,7 @@
   "pnl-error": "Solución de errores PNL",
   "pnl-help": "La liquidación actualizará su saldo en USDC para reflejar el monto de PnL pendiente.",
   "pnl-success": "PNL resuelto con éxito",
-  "portfolio": "portafolio",
+  "portfolio": "Portafolio",
   "position": "Posición",
   "position-size": "Tamaño de la posición",
   "positions": "Posiciones",


### PR DESCRIPTION
- Capitalizes `Portafolio` in Spanish translation
- Hides price placeholder when market type and post only slide is enabled