### PR TITLE
add missing translation key

### DIFF
--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -401,6 +401,7 @@
    "tooltip-lock-layout": "Diseño de bloqueo",
    "tooltip-name-onchain": "Los nombres de las cuentas se almacenan en cadena",
    "tooltip-post": "Se garantiza que las órdenes de envío solo serán el pedido del fabricante o, de lo contrario, se cancelará.",
+   "tooltip-post-and-slide": "Post and slide is a limit order that will set your price one tick more/less than the opposite side of the book.",
    "tooltip-projected-leverage": "Apalancamiento proyectado",
    "tooltip-reduce": "Reducir solamente ordenes solo reducirá su posición general.",
    "tooltip-reset-layout": "Restablecer diseño",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -401,6 +401,7 @@
     "tooltip-lock-layout": "锁定页面布局",
     "tooltip-name-onchain": "帐户标签是在区块链上存保的",
     "tooltip-post": "Post交易若不挂单就会被取消。",
+    "tooltip-post-and-slide": "Post and slide is a limit order that will set your price one tick more/less than the opposite side of the book.",
     "tooltip-projected-leverage": "预计杠杆",
     "tooltip-reduce": "Reduce交易只能减少您的持仓。",
     "tooltip-reset-layout": "重置页面布局",

--- a/public/locales/zh_tw/common.json
+++ b/public/locales/zh_tw/common.json
@@ -401,6 +401,7 @@
   "tooltip-lock-layout": "鎖定頁面佈局",
   "tooltip-name-onchain": "帳戶標籤是在區塊鏈上存保的",
   "tooltip-post": "Post交易若不掛單就會被取消。",
+  "tooltip-post-and-slide": "Post and slide is a limit order that will set your price one tick more/less than the opposite side of the book.",
   "tooltip-projected-leverage": "預計槓桿",
   "tooltip-reduce": "Reduce交易只能減少您的持倉。",
   "tooltip-reset-layout": "重置頁面佈局",


### PR DESCRIPTION
"tooltip-post-and-slide" was missing in es, zh, zh_tw locales
