### PR TITLE
format price on trade type switch

### DIFF
--- a/components/trade_form/AdvancedTradeForm.tsx
+++ b/components/trade_form/AdvancedTradeForm.tsx
@@ -413,7 +413,10 @@ export default function AdvancedTradeForm({
     } else {
       const priceOnBook = side === 'buy' ? orderbook?.asks : orderbook?.bids
       if (priceOnBook && priceOnBook.length > 0 && priceOnBook[0].length > 0) {
-        setPrice(priceOnBook[0][0])
+        const formattedPrice = market?.tickSize
+          ? priceOnBook[0][0].toFixed(getDecimalCount(market?.tickSize))
+          : priceOnBook[0][0]
+        setPrice(formattedPrice)
       }
       setIoc(false)
     }


### PR DESCRIPTION
Price sometimes had a lot of decimals when switching from market to limit type trades. Now has a max precision of ticksize decimals

Noticed that sometimes the price at the top of the book is different from the price populated for a market order. This is instantly after selecting market. Not sure if this is expected or not.
<img width="515" alt="Screen Shot 2022-04-06 at 3 46 07 pm" src="https://user-images.githubusercontent.com/30796577/161892119-1ba40aaa-7871-4737-850f-16441efa2971.png">

