### PR TITLE
fix forwardref warning

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -11,9 +11,8 @@ interface InputProps {
   [x: string]: any
 }
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({
-    ref,
+const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+  const {
     type,
     value,
     onChange,
@@ -24,19 +23,18 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     prefix,
     prefixClassName,
     suffix,
-    ...props
-  }) => {
-    return (
-      <div className={`relative flex ${wrapperClassName}`}>
-        {prefix ? (
-          <div
-            className={`absolute left-2 top-1/2 -translate-y-1/2 transform ${prefixClassName}`}
-          >
-            {prefix}
-          </div>
-        ) : null}
-        <input
-          className={`${className} h-10 w-full flex-1 rounded-md border bg-th-bkg-1 px-2 pb-px
+  } = props
+  return (
+    <div className={`relative flex ${wrapperClassName}`}>
+      {prefix ? (
+        <div
+          className={`absolute left-2 top-1/2 -translate-y-1/2 transform ${prefixClassName}`}
+        >
+          {prefix}
+        </div>
+      ) : null}
+      <input
+        className={`${className} h-10 w-full flex-1 rounded-md border bg-th-bkg-1 px-2 pb-px
           text-th-fgd-1 ${
             error ? 'border-th-red' : 'border-th-bkg-4'
           } default-transition hover:border-th-fgd-4 
@@ -48,22 +46,21 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           }
           ${prefix ? 'pl-7' : ''}
           ${suffix ? 'pr-11' : ''}`}
-          disabled={disabled}
-          ref={ref}
-          {...props}
-          type={type}
-          value={value}
-          onChange={onChange}
-        />
-        {suffix ? (
-          <span className="absolute right-0 flex h-full items-center bg-transparent pr-2 text-xs text-th-fgd-4">
-            {suffix}
-          </span>
-        ) : null}
-      </div>
-    )
-  }
-)
+        disabled={disabled}
+        ref={ref}
+        {...props}
+        type={type}
+        value={value}
+        onChange={onChange}
+      />
+      {suffix ? (
+        <span className="absolute right-0 flex h-full items-center bg-transparent pr-2 text-xs text-th-fgd-4">
+          {suffix}
+        </span>
+      ) : null}
+    </div>
+  )
+})
 
 export default Input
 


### PR DESCRIPTION
Get this warning locally:

Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?

Doesn't show up in prod so not sure if this is necessary.
