### PR TITLE
move estimated liquidation price to position details

### DIFF
--- a/components/AccountInfo.tsx
+++ b/components/AccountInfo.tsx
@@ -142,15 +142,6 @@ export default function AccountInfo() {
       ? mangoAccount.getHealth(mangoGroup, mangoCache, 'Init')
       : I80F48_100
 
-  const liquidationPrice =
-    mangoGroup && mangoAccount && marketConfig && mangoGroup && mangoCache
-      ? mangoAccount.getLiquidationPrice(
-          mangoGroup,
-          mangoCache,
-          marketConfig.marketIndex
-        )
-      : undefined
-
   return (
     <>
       <div
@@ -262,16 +253,6 @@ export default function AccountInfo() {
                       ).toFixed()
                     )
                   : '0.00'}
-              </div>
-            </div>
-            <div className={`flex justify-between pb-2`}>
-              <div className="font-normal leading-4 text-th-fgd-3">
-                {marketConfig.name} {t('estimated-liq-price')}
-              </div>
-              <div className={`text-th-fgd-1`}>
-                {liquidationPrice && liquidationPrice.gt(ZERO_I80F48)
-                  ? usdFormatter(liquidationPrice)
-                  : 'N/A'}
               </div>
             </div>
             <div className={`flex justify-between pb-2`}>

--- a/components/MarketPosition.tsx
+++ b/components/MarketPosition.tsx
@@ -11,6 +11,7 @@ import {
   PerpAccount,
   PerpMarket,
   QUOTE_INDEX,
+  ZERO_I80F48,
 } from '@blockworks-foundation/mango-client'
 import { notify } from '../utils/notifications'
 import MarketCloseModal from './MarketCloseModal'
@@ -227,6 +228,15 @@ export default function MarketPosition() {
     )
   }
 
+  const liquidationPrice =
+    mangoGroup && mangoAccount && marketConfig && mangoGroup && mangoCache
+      ? mangoAccount.getLiquidationPrice(
+          mangoGroup,
+          mangoCache,
+          marketConfig.marketIndex
+        )
+      : undefined
+
   return (
     <>
       <div
@@ -277,6 +287,16 @@ export default function MarketPosition() {
             ) : (
               '$0'
             )}
+          </div>
+        </div>
+        <div className={`flex justify-between pb-2`}>
+          <div className="font-normal leading-4 text-th-fgd-3">
+            {t('estimated-liq-price')}
+          </div>
+          <div className={`text-th-fgd-1`}>
+            {liquidationPrice && liquidationPrice.gt(ZERO_I80F48)
+              ? formatUsdValue(Number(liquidationPrice))
+              : 'N/A'}
           </div>
         </div>
         <div className="flex justify-between pb-2">

--- a/components/TradePageGrid.tsx
+++ b/components/TradePageGrid.tsx
@@ -27,7 +27,7 @@ export const defaultLayouts = {
   xl: [
     { i: 'tvChart', x: 0, y: 0, w: 6, h: 27 },
     { i: 'marketPosition', x: 9, y: 4, w: 3, h: 13 },
-    { i: 'accountInfo', x: 9, y: 3, w: 3, h: 14 },
+    { i: 'accountInfo', x: 9, y: 3, w: 3, h: 13 },
     { i: 'orderbook', x: 6, y: 0, w: 3, h: 17 },
     { i: 'tradeForm', x: 9, y: 1, w: 3, h: 17 },
     { i: 'marketTrades', x: 6, y: 1, w: 3, h: 10 },
@@ -36,7 +36,7 @@ export const defaultLayouts = {
   lg: [
     { i: 'tvChart', x: 0, y: 0, w: 6, h: 27, minW: 2 },
     { i: 'marketPosition', x: 9, y: 2, w: 3, h: 13, minW: 2 },
-    { i: 'accountInfo', x: 9, y: 1, w: 3, h: 14, minW: 2 },
+    { i: 'accountInfo', x: 9, y: 1, w: 3, h: 13, minW: 2 },
     { i: 'orderbook', x: 6, y: 2, w: 3, h: 17, minW: 2 },
     { i: 'tradeForm', x: 9, y: 0, w: 3, h: 17, minW: 3 },
     { i: 'marketTrades', x: 6, y: 2, w: 3, h: 10, minW: 2 },
@@ -45,7 +45,7 @@ export const defaultLayouts = {
   md: [
     { i: 'tvChart', x: 0, y: 0, w: 8, h: 25, minW: 2 },
     { i: 'marketPosition', x: 8, y: 1, w: 4, h: 11, minW: 2 },
-    { i: 'accountInfo', x: 8, y: 0, w: 4, h: 14, minW: 2 },
+    { i: 'accountInfo', x: 8, y: 0, w: 4, h: 13, minW: 2 },
     { i: 'orderbook', x: 0, y: 2, w: 4, h: 19, minW: 2 },
     { i: 'tradeForm', x: 4, y: 2, w: 4, h: 19, minW: 3 },
     { i: 'marketTrades', x: 8, y: 2, w: 4, h: 19, minW: 2 },
@@ -54,7 +54,7 @@ export const defaultLayouts = {
   sm: [
     { i: 'tvChart', x: 0, y: 0, w: 12, h: 20, minW: 6 },
     { i: 'marketPosition', x: 0, y: 1, w: 6, h: 14, minW: 6 },
-    { i: 'accountInfo', x: 6, y: 1, w: 6, h: 14, minW: 6 },
+    { i: 'accountInfo', x: 6, y: 1, w: 6, h: 13, minW: 6 },
     { i: 'tradeForm', x: 0, y: 2, w: 12, h: 17, minW: 6 },
     { i: 'orderbook', x: 0, y: 3, w: 6, h: 17, minW: 6 },
     { i: 'marketTrades', x: 6, y: 3, w: 6, h: 17, minW: 6 },
@@ -62,7 +62,7 @@ export const defaultLayouts = {
   ],
 }
 
-export const GRID_LAYOUT_KEY = 'mangoSavedLayouts-3.1.6'
+export const GRID_LAYOUT_KEY = 'mangoSavedLayouts-3.1.7'
 export const breakpoints = { xl: 1600, lg: 1280, md: 1024, sm: 768 }
 
 const getCurrentBreakpoint = () => {


### PR DESCRIPTION
Moves estimated liquidation price from the account panel to the position panel. Think it probably makes more sense to sit here and it will show on mobile. Also added to the positions table.
