### PR TITLE
add "names" arg to account graph buttongroup

### DIFF
--- a/components/account_page/PerformanceChart.tsx
+++ b/components/account_page/PerformanceChart.tsx
@@ -247,7 +247,8 @@ const PerformanceChart = ({
               activeValue={chartToShow}
               className="pb-2 pt-2 text-sm"
               onChange={(v) => setChartToShow(v)}
-              values={[t('value'), t('pnl')]}
+              values={['Value', 'PnL']}
+              names={[t('value'), t('pnl')]}
             />
           </div>
 


### PR DESCRIPTION
The account performance chart "value" and "PnL" buttons weren't working properly on the non-English UI. This PR adds the "names" argument as the localized text and retains the English strings as the "values" arg.

![Screenshot 2022-05-09 210551](https://user-images.githubusercontent.com/4095852/167541703-16f4f09e-689d-4b9b-9bb2-afe89b9ae412.png)
![Screenshot 2022-05-09 210617](https://user-images.githubusercontent.com/4095852/167541709-37769a5d-b22a-4f9d-83d6-79b549bccb8a.png)

PR Requirements:

- [x] Summarize changes
- [x] Included a screenshot, if applicable
- [x] Test on mobile
- [x] Request at least one reviewer
