### PR TITLE
Fix Risk Calculator PERP loading unreliably

### DIFF
--- a/components/account_page/AccountPerformancePerToken.tsx
+++ b/components/account_page/AccountPerformancePerToken.tsx
@@ -183,11 +183,11 @@ const AccountPerformance = () => {
 
     // Normalise chart to start from 0 (except for account value)
     if (parseInt(performanceRange) !== 90 && chartToShow !== 'account-value') {
-      const startValues = Object.assign({}, stats[0]);
-      for (let i = 0; i < stats.length; i++ ) {
+      const startValues = Object.assign({}, stats[0])
+      for (let i = 0; i < stats.length; i++) {
         for (const key in stats[i]) {
           if (key !== 'time') {
-            stats[i][key] = stats[i][key] - startValues[key];
+            stats[i][key] = stats[i][key] - startValues[key]
           }
         }
       }

--- a/pages/risk-calculator.tsx
+++ b/pages/risk-calculator.tsx
@@ -312,21 +312,43 @@ export default function RiskCalculator() {
       if (!symbol) return
       // Retrieve perp positions if present
       const perpPosition = mangoAccount?.perpAccounts[i] || null
-      const basePosition = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.basePosition) 
-      / Math.pow(10, perpContractPrecision[symbol]) || 0
-      const unsettledFunding = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getUnsettledFunding(mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)])) 
-      / Math.pow(10, 6) || 0
-      const positionPnL = Number(
-            mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getPnl(
-                mangoGroup?.perpMarkets[getMarketIndexBySymbol(mangoConfig, symbol)],
-                mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)],
-                mangoCache.priceCache[getMarketIndexBySymbol(mangoConfig, symbol)].price
-              )
-            ) / Math.pow(10, 6) || 0
-      const perpBids = Number(perpPosition?.bidsQuantity) 
-      / Math.pow(10, perpContractPrecision[symbol]) || 0
-      const perpAsks = Number(perpPosition?.asksQuantity) 
-      / Math.pow(10, perpContractPrecision[symbol]) || 0
+      const basePosition =
+        Number(
+          mangoAccount?.perpAccounts[
+            getMarketIndexBySymbol(mangoConfig, symbol)
+          ]?.basePosition
+        ) / Math.pow(10, perpContractPrecision[symbol]) || 0
+      const unsettledFunding =
+        Number(
+          mangoAccount?.perpAccounts[
+            getMarketIndexBySymbol(mangoConfig, symbol)
+          ]?.getUnsettledFunding(
+            mangoCache?.perpMarketCache[
+              getMarketIndexBySymbol(mangoConfig, symbol)
+            ]
+          )
+        ) / Math.pow(10, 6) || 0
+      const positionPnL =
+        Number(
+          mangoAccount?.perpAccounts[
+            getMarketIndexBySymbol(mangoConfig, symbol)
+          ]?.getPnl(
+            mangoGroup?.perpMarkets[
+              getMarketIndexBySymbol(mangoConfig, symbol)
+            ],
+            mangoCache?.perpMarketCache[
+              getMarketIndexBySymbol(mangoConfig, symbol)
+            ],
+            mangoCache.priceCache[getMarketIndexBySymbol(mangoConfig, symbol)]
+              .price
+          )
+        ) / Math.pow(10, 6) || 0
+      const perpBids =
+        Number(perpPosition?.bidsQuantity) /
+          Math.pow(10, perpContractPrecision[symbol]) || 0
+      const perpAsks =
+        Number(perpPosition?.asksQuantity) /
+          Math.pow(10, perpContractPrecision[symbol]) || 0
 
       if (
         spotMarketConfig?.publicKey ||
@@ -704,18 +726,40 @@ export default function RiskCalculator() {
                       )
 
                 // Retrieve perp positions if present
-                const perpPosition = mangoAccount?.perpAccounts[asset.oracleIndex] || null
-                const basePosition = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.basePosition)
-                  / Math.pow(10, perpContractPrecision[symbol]) || 0
-                const unsettledFunding = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getUnsettledFunding(mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)]))
-                  / Math.pow(10, 6) || 0
-                const positionPnL = Number(
-                  mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getPnl(
-                    mangoGroup?.perpMarkets[getMarketIndexBySymbol(mangoConfig, symbol)],
-                    mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)],
-                    mangoCache.priceCache[getMarketIndexBySymbol(mangoConfig, symbol)].price
-                  )
-                ) / Math.pow(10, 6) || 0
+                const perpPosition =
+                  mangoAccount?.perpAccounts[asset.oracleIndex] || null
+                const basePosition =
+                  Number(
+                    mangoAccount?.perpAccounts[
+                      getMarketIndexBySymbol(mangoConfig, symbol)
+                    ]?.basePosition
+                  ) / Math.pow(10, perpContractPrecision[symbol]) || 0
+                const unsettledFunding =
+                  Number(
+                    mangoAccount?.perpAccounts[
+                      getMarketIndexBySymbol(mangoConfig, symbol)
+                    ]?.getUnsettledFunding(
+                      mangoCache?.perpMarketCache[
+                        getMarketIndexBySymbol(mangoConfig, symbol)
+                      ]
+                    )
+                  ) / Math.pow(10, 6) || 0
+                const positionPnL =
+                  Number(
+                    mangoAccount?.perpAccounts[
+                      getMarketIndexBySymbol(mangoConfig, symbol)
+                    ]?.getPnl(
+                      mangoGroup?.perpMarkets[
+                        getMarketIndexBySymbol(mangoConfig, symbol)
+                      ],
+                      mangoCache?.perpMarketCache[
+                        getMarketIndexBySymbol(mangoConfig, symbol)
+                      ],
+                      mangoCache.priceCache[
+                        getMarketIndexBySymbol(mangoConfig, symbol)
+                      ].price
+                    )
+                  ) / Math.pow(10, 6) || 0
                 const perpInOrders = perpMarketConfig?.publicKey
                   ? Number(perpPosition?.bidsQuantity) >
                     Math.abs(Number(perpPosition?.asksQuantity))

--- a/pages/risk-calculator.tsx
+++ b/pages/risk-calculator.tsx
@@ -311,61 +311,22 @@ export default function RiskCalculator() {
       }
       if (!symbol) return
       // Retrieve perp positions if present
-      const perpPosition =
-        perpMarketConfig?.publicKey && mangoAccount
-          ? mangoAccount?.perpAccounts[i]
-          : null
-      const perpMarketIndex =
-        perpMarketConfig?.publicKey && mangoAccount
-          ? getMarketIndexBySymbol(mangoConfig, symbol)
-          : null
-      const perpAccount =
-        perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-          ? mangoAccount?.perpAccounts[perpMarketIndex]
-          : null
-      const perpMarketCache =
-        perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-          ? mangoCache?.perpMarketCache[perpMarketIndex]
-          : null
-      const perpMarketInfo =
-        perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-          ? mangoGroup?.perpMarkets[perpMarketIndex]
-          : null
-      const basePosition =
-        perpMarketConfig?.publicKey && mangoAccount
-          ? Number(perpAccount?.basePosition) /
-              Math.pow(10, perpContractPrecision[symbol]) || 0
-          : 0
-      const unsettledFunding =
-        perpMarketConfig?.publicKey && mangoAccount && perpMarketCache
-          ? (Number(perpAccount?.getUnsettledFunding(perpMarketCache)) *
-              basePosition) /
-              Math.pow(10, 6) || 0
-          : 0
-      const positionPnL =
-        perpMarketConfig?.publicKey &&
-        mangoAccount &&
-        perpMarketIndex &&
-        perpMarketInfo &&
-        perpMarketCache
-          ? Number(
-              perpAccount?.getPnl(
-                perpMarketInfo,
-                perpMarketCache,
-                mangoCache.priceCache[perpMarketIndex].price
+      const perpPosition = mangoAccount?.perpAccounts[i] || null
+      const basePosition = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.basePosition) 
+      / Math.pow(10, perpContractPrecision[symbol]) || 0
+      const unsettledFunding = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getUnsettledFunding(mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)])) 
+      / Math.pow(10, 6) || 0
+      const positionPnL = Number(
+            mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getPnl(
+                mangoGroup?.perpMarkets[getMarketIndexBySymbol(mangoConfig, symbol)],
+                mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)],
+                mangoCache.priceCache[getMarketIndexBySymbol(mangoConfig, symbol)].price
               )
             ) / Math.pow(10, 6) || 0
-          : 0
-      const perpBids =
-        perpMarketConfig?.publicKey && mangoAccount
-          ? Number(perpPosition?.bidsQuantity) /
-              Math.pow(10, perpContractPrecision[symbol]) || 0
-          : Number(0)
-      const perpAsks =
-        perpMarketConfig?.publicKey && mangoAccount
-          ? Number(perpPosition?.asksQuantity) /
-              Math.pow(10, perpContractPrecision[symbol]) || 0
-          : Number(0)
+      const perpBids = Number(perpPosition?.bidsQuantity) 
+      / Math.pow(10, perpContractPrecision[symbol]) || 0
+      const perpAsks = Number(perpPosition?.asksQuantity) 
+      / Math.pow(10, perpContractPrecision[symbol]) || 0
 
       if (
         spotMarketConfig?.publicKey ||
@@ -743,53 +704,18 @@ export default function RiskCalculator() {
                       )
 
                 // Retrieve perp positions if present
-                const perpPosition =
-                  perpMarketConfig?.publicKey && mangoAccount
-                    ? mangoAccount?.perpAccounts[asset.oracleIndex]
-                    : null
-                const perpMarketIndex =
-                  perpMarketConfig?.publicKey && mangoAccount
-                    ? getMarketIndexBySymbol(mangoConfig, symbol)
-                    : null
-                const perpAccount =
-                  perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-                    ? mangoAccount?.perpAccounts[perpMarketIndex]
-                    : null
-                const perpMarketCache =
-                  perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-                    ? mangoCache?.perpMarketCache[perpMarketIndex]
-                    : null
-                const perpMarketInfo =
-                  perpMarketConfig?.publicKey && mangoAccount && perpMarketIndex
-                    ? mangoGroup?.perpMarkets[perpMarketIndex]
-                    : null
-                const basePosition =
-                  perpMarketConfig?.publicKey && mangoAccount
-                    ? Number(perpAccount?.basePosition) /
-                      Math.pow(10, perpContractPrecision[symbol])
-                    : 0
-                const unsettledFunding =
-                  perpMarketConfig?.publicKey && mangoAccount && perpMarketCache
-                    ? (Number(
-                        perpAccount?.getUnsettledFunding(perpMarketCache)
-                      ) *
-                        basePosition) /
-                      Math.pow(10, 6)
-                    : 0
-                const positionPnL =
-                  perpMarketConfig?.publicKey &&
-                  mangoAccount &&
-                  perpMarketIndex &&
-                  perpMarketInfo &&
-                  perpMarketCache
-                    ? Number(
-                        perpAccount?.getPnl(
-                          perpMarketInfo,
-                          perpMarketCache,
-                          mangoCache.priceCache[perpMarketIndex].price
-                        )
-                      ) / Math.pow(10, 6)
-                    : 0
+                const perpPosition = mangoAccount?.perpAccounts[asset.oracleIndex] || null
+                const basePosition = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.basePosition)
+                  / Math.pow(10, perpContractPrecision[symbol]) || 0
+                const unsettledFunding = Number(mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getUnsettledFunding(mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)]))
+                  / Math.pow(10, 6) || 0
+                const positionPnL = Number(
+                  mangoAccount?.perpAccounts[getMarketIndexBySymbol(mangoConfig, symbol)]?.getPnl(
+                    mangoGroup?.perpMarkets[getMarketIndexBySymbol(mangoConfig, symbol)],
+                    mangoCache?.perpMarketCache[getMarketIndexBySymbol(mangoConfig, symbol)],
+                    mangoCache.priceCache[getMarketIndexBySymbol(mangoConfig, symbol)].price
+                  )
+                ) / Math.pow(10, 6) || 0
                 const perpInOrders = perpMarketConfig?.publicKey
                   ? Number(perpPosition?.bidsQuantity) >
                     Math.abs(Number(perpPosition?.asksQuantity))
@@ -798,7 +724,7 @@ export default function RiskCalculator() {
                         tokenPrecision[perpMarketConfig?.baseSymbol] || 6
                       )
                     : floorToDecimal(
-                        -1 * Number(perpPosition?.asksQuantity),
+                        Number(perpPosition?.asksQuantity),
                         tokenPrecision[perpMarketConfig?.baseSymbol] || 6
                       )
                   : 0


### PR DESCRIPTION
- Removed reliance on multiple variables for loading perp positions, notably making the MNGO-PERP fail to load correctly.
- Removed base position from Unsettled Funding calculation as it's displayed in quote token, not the perp token
- Fixed perps In Orders calculation so it was consistent in both places it's present
