### PR TITLE
allow filter when >10k trades

### DIFF
--- a/components/TradeHistoryFilterModal.tsx
+++ b/components/TradeHistoryFilterModal.tsx
@@ -9,17 +9,19 @@ import dayjs from 'dayjs'
 import DateRangePicker from './DateRangePicker'
 import useMangoStore from 'stores/useMangoStore'
 import MultiSelectDropdown from './MultiSelectDropdown'
+import InlineNotification from './InlineNotification'
 
 interface TradeHistoryFilterModalProps {
   filters: any
   setFilters: any
   isOpen: boolean
   onClose: () => void
+  showApiWarning: boolean
 }
 
 const TradeHistoryFilterModal: FunctionComponent<
   TradeHistoryFilterModalProps
-> = ({ filters, setFilters, isOpen, onClose }) => {
+> = ({ filters, setFilters, isOpen, onClose, showApiWarning }) => {
   const { t } = useTranslation('common')
   const [newFilters, setNewFilters] = useState({ ...filters })
   const [dateFrom, setDateFrom] = useState<Date | null>(null)
@@ -173,6 +175,14 @@ const TradeHistoryFilterModal: FunctionComponent<
           </LinkButton>
         </div>
       </Modal.Header>
+      {showApiWarning ? (
+        <div className="mt-1 mb-3">
+          <InlineNotification
+            type="warning"
+            desc={t('trade-history-api-warning')}
+          />
+        </div>
+      ) : null}
       <div className="pb-4">
         <p className="font-bold text-th-fgd-1">{t('date')}</p>
         <div className="flex items-center space-x-2">

--- a/components/TradeHistoryTable.tsx
+++ b/components/TradeHistoryTable.tsx
@@ -205,9 +205,7 @@ const TradeHistoryTable = ({
                 {t('reset-filters')}
               </LinkButton>
             ) : null}
-            {tradeHistory.length >= 15 &&
-            tradeHistory.length <= 10000 &&
-            initialLoad ? (
+            {tradeHistory.length >= 15 && initialLoad ? (
               <Button
                 className="order-3 flex h-8 items-center justify-center whitespace-nowrap pt-0 pb-0 pl-3 pr-3 text-xs sm:order-first"
                 onClick={() => setShowFiltersModal(true)}
@@ -625,6 +623,7 @@ const TradeHistoryTable = ({
           setFilters={setFilters}
           isOpen={showFiltersModal}
           onClose={() => setShowFiltersModal(false)}
+          showApiWarning={tradeHistory.length > 10000}
         />
       ) : null}
     </>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -430,6 +430,7 @@
    "trade": "Trade",
    "trade-export-disclaimer": "Due to the nature of how trades are processed, it is not possible to guarantee that all trades will be exported. However, a best effort approach has been taken, combining several independent sources to reduce the likelihood of missing trades.",
    "trade-history": "Trade History",
+   "trade-history-api-warning": "Trade history shows a maximum of 10,000 trades. Some trades will not be found.",
    "trades": "Trades",
    "trades-history": "Trade History",
    "transaction-failed": "Transaction failed",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -430,6 +430,7 @@
    "trade": "Comercio",
    "trade-export-disclaimer": "Due to the nature of how trades are processed, it is not possible to guarantee that all trades will be exported. However, a best effort approach has been taken, combining several independent sources to reduce the likelihood of missing trades.",
    "trade-history": "Historial comercial",
+   "trade-history-api-warning": "Trade history shows a maximum of 10,000 trades. Some trades will not be found.",
    "trades": "Trades",
    "trades-history": "Historial comercial",
    "transaction-failed": "Transaction failed",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -430,6 +430,7 @@
     "trade": "交易",
     "trade-export-disclaimer": "Mango尽量以几个独立的来源结合成完整交易历史，但由于交易处理方式，Mango无法保证所有交易都会导出。",
     "trade-history": "交易纪录",
+    "trade-history-api-warning": "Trade history shows a maximum of 10,000 trades. Some trades will not be found.",
     "trades": "交易",
     "trades-history": "交易纪录",
     "transaction-failed": "交易失败",

--- a/public/locales/zh_tw/common.json
+++ b/public/locales/zh_tw/common.json
@@ -430,6 +430,7 @@
   "trade": "交易",
   "trade-export-disclaimer": "Mango儘量以幾個獨立的來源結合成完整交易歷史，但由於交易處理方式，Mango無法保證所有交易都會導出。",
   "trade-history": "交易紀錄",
+  "trade-history-api-warning": "Trade history shows a maximum of 10,000 trades. Some trades will not be found.",
   "trades": "交易",
   "trades-history": "交易紀錄",
   "transaction-failed": "交易失敗",


### PR DESCRIPTION
No longer hides the trade history filter button and adds a warning to the filter modal when trades are >10k

Requested in Discord:
https://discord.com/channels/791995070613159966/833812133316657183/981496647886442536
