### PR TITLE
validate first deposit amount input

### DIFF
--- a/components/NewAccount.tsx
+++ b/components/NewAccount.tsx
@@ -56,36 +56,39 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
 
   const handleNewAccountDeposit = () => {
     if (!wallet) return
-    setSubmitting(true)
-    deposit({
-      amount: parseFloat(inputAmount),
-      fromTokenAcc: selectedAccount.account,
-      accountName: name,
-      wallet,
-    })
-      .then(async (response) => {
-        await sleep(1000)
-        actions.fetchWalletTokens(wallet)
-        actions.fetchAllMangoAccounts(wallet)
-        if (response && response.length > 0) {
-          onAccountCreation(response[0])
-          notify({
-            title: 'Mango Account Created',
-            txid: response[1],
-          })
-        }
-        setSubmitting(false)
+    validateAmountInput(inputAmount)
+    if (inputAmount) {
+      setSubmitting(true)
+      deposit({
+        amount: parseFloat(inputAmount),
+        fromTokenAcc: selectedAccount.account,
+        accountName: name,
+        wallet,
       })
-      .catch((e) => {
-        setSubmitting(false)
-        console.error(e)
-        notify({
-          title: t('init-error'),
-          description: e.message,
-          type: 'error',
+        .then(async (response) => {
+          await sleep(1000)
+          actions.fetchWalletTokens(wallet)
+          actions.fetchAllMangoAccounts(wallet)
+          if (response && response.length > 0) {
+            onAccountCreation(response[0])
+            notify({
+              title: 'Mango Account Created',
+              txid: response[1],
+            })
+          }
+          setSubmitting(false)
         })
-        onAccountCreation()
-      })
+        .catch((e) => {
+          setSubmitting(false)
+          console.error(e)
+          notify({
+            title: t('init-error'),
+            description: e.message,
+            type: 'error',
+          })
+          onAccountCreation()
+        })
+    }
   }
 
   const validateAmountInput = (amount) => {
@@ -184,7 +187,7 @@ const NewAccount: FunctionComponent<NewAccountProps> = ({
         suffix={symbol}
       />
       {invalidAmountMessage ? (
-        <div className="flex items-center pt-1.5 text-th-red">
+        <div className="flex items-center py-1.5 text-th-red">
           <ExclamationCircleIcon className="mr-1.5 h-4 w-4" />
           {invalidAmountMessage}
         </div>


### PR DESCRIPTION
Currently, the create account transaction submits and fails if no deposit amount is entered. This validates an amount
