### PR TITLE
filter low volume tokens from swap insights

### DIFF
--- a/components/SwapTokenInsights.tsx
+++ b/components/SwapTokenInsights.tsx
@@ -36,8 +36,9 @@ const SwapTokenInsights = ({ formState, jupiterTokens, setOutputToken }) => {
       `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids.toString()}&order=market_cap_desc&sparkline=false&price_change_percentage=24h,7d,30d`
     )
     const data = await response.json()
+    const filterMicroVolume = data.filter((token) => token.total_volume > 10000)
     setLoading(false)
-    setTokenInsights(data)
+    setTokenInsights(filterMicroVolume)
   }
 
   useEffect(() => {


### PR DESCRIPTION
Most of the time the best/worst performing tokens are the ones with almost 0 volume. This makes the minimum 24h volume $10000
