### PR TITLE
improve swap description

### DIFF
--- a/components/JupiterForm.tsx
+++ b/components/JupiterForm.tsx
@@ -376,7 +376,7 @@ const JupiterForm: FunctionComponent = () => {
               }`}
             >
               <aside
-                className={`ml-16 w-64 rounded-l-md bg-th-bkg-3 pb-4 pt-6`}
+                className={`ml-16 w-64 rounded-l-md bg-th-bkg-2 pb-4 pt-6`}
               >
                 <div className="thin-scroll max-h-[480px] overflow-auto">
                   <div className="flex items-center justify-between px-4 pb-2">
@@ -472,7 +472,7 @@ const JupiterForm: FunctionComponent = () => {
                 </div>
               </aside>
               <button
-                className="absolute right-64 top-20 rounded-r-none bg-th-bkg-4 p-3 text-th-fgd-1 md:hover:text-th-primary"
+                className="absolute right-64 top-1/2 -translate-y-1/2 transform rounded-r-none bg-th-bkg-4 p-3 text-th-fgd-1 md:hover:text-th-primary"
                 onClick={() => setShowWalletDraw(!showWalletDraw)}
               >
                 <WalletIcon className="h-5 w-5" />

--- a/pages/swap.tsx
+++ b/pages/swap.tsx
@@ -9,6 +9,10 @@ import { useTranslation } from 'next-i18next'
 import { useWallet } from '@solana/wallet-adapter-react'
 import useLocalStorageState from 'hooks/useLocalStorageState'
 import dayjs from 'dayjs'
+import {
+  InformationCircleIcon,
+  LightningBoltIcon,
+} from '@heroicons/react/solid'
 
 export async function getStaticProps({ locale }) {
   return {
@@ -53,15 +57,21 @@ export default function Swap() {
       userPublicKey={connected ? userPublicKey : undefined}
     >
       <div className="mb-1 flex flex-col items-start pt-6 pb-4 md:flex-row md:items-end md:justify-between">
-        <h1 className={`mb-1.5 md:mb-0`}>{t('swap')}</h1>
-        <div className="flex flex-col md:items-end">
-          <p className="mb-0 text-xs">{t('swap:swap-between-hundreds')}</p>
+        <div className="pb-1 md:pb-0">
+          <h1 className={`mb-1`}>{t('swap')}</h1>
+          <div className="flex items-center">
+            <InformationCircleIcon className="mr-1 h-4 w-4 text-th-fgd-4" />
+            <p className="mb-0 text-xs text-th-fgd-4">{t('swap:swap-desc')}</p>
+          </div>
+        </div>
+        <div className="flex flex-col md:items-end md:pl-4">
           <a
-            className="mb-0 text-xs text-th-fgd-2"
+            className="mb-0 flex items-center whitespace-nowrap text-xs text-th-fgd-2"
             href="https://jup.ag/swap/USDC-MNGO"
             target="_blank"
             rel="noopener noreferrer"
           >
+            <LightningBoltIcon className="mr-1 h-4 w-4 text-th-fgd-4" />
             Powered by Jupiter
           </a>
         </div>

--- a/public/locales/en/swap.json
+++ b/public/locales/en/swap.json
@@ -41,6 +41,7 @@
   "slippage": "Slippage",
   "slippage-settings": "Slippage Settings",
   "swap-between-hundreds": "Swap between 100s of tokens at the best rates.",
+  "swap-desc": "Swap interacts with your connected wallet (not your Mango Account).",
   "swap-details": "Swap Details",
   "swap-fee": "Swap Fee",
   "swap-in-wallet": "Swaps interact directly with your connected wallet, not your Mango Account.",

--- a/public/locales/es/swap.json
+++ b/public/locales/es/swap.json
@@ -41,6 +41,7 @@
   "slippage": "Slippage",
   "slippage-settings": "Slippage Settings",
   "swap-between-hundreds": "Swap between 100s of tokens at the best rates.",
+  "swap-desc": "Swap interacts with your connected wallet (not your Mango Account).",
   "swap-details": "Swap Details",
   "swap-fee": "Swap Fee",
   "swap-in-wallet": "Swaps interact directly with your connected wallet, not your Mango Account.",

--- a/public/locales/zh/swap.json
+++ b/public/locales/zh/swap.json
@@ -41,6 +41,7 @@
   "slippage": "滑点",
   "slippage-settings": "滑点设定",
   "swap-between-hundreds": "以最好价格来换几百个币种。",
+  "swap-desc": "Swap interacts with your connected wallet (not your Mango Account).",
   "swap-details": "换币细节",
   "swap-fee": "换币费用",
   "swap-in-wallet": "换币会在您被连结的钱包中进行而不在您的Mango帐户中。",

--- a/public/locales/zh_tw/swap.json
+++ b/public/locales/zh_tw/swap.json
@@ -41,6 +41,7 @@
   "slippage": "滑點",
   "slippage-settings": "滑點設定",
   "swap-between-hundreds": "以最好價格來換幾百個幣種。",
+  "swap-desc": "Swap interacts with your connected wallet (not your Mango Account).",
   "swap-details": "換幣細節",
   "swap-fee": "換幣費用",
   "swap-in-wallet": "換幣會在您被連結的錢包中進行而不在您的Mango帳戶中。",


### PR DESCRIPTION
Let users know swaps interact with their connected wallet, not their Mango Account
