### PR TITLE
Override locale detection with user setting

### DIFF
--- a/components/AlphaModal.tsx
+++ b/components/AlphaModal.tsx
@@ -35,7 +35,7 @@ const AlphaModal = ({
 
   const handleLanguageSelect = () => {
     setSavedLanguage(language)
-    document.cookie = `NEXT_LOCALE=${savedLanguage}; max-age=31536000; path=/`
+    document.cookie = `NEXT_LOCALE=${language}; max-age=31536000; path=/`
     router.push({ pathname, query }, asPath, { locale: language })
     dayjs.locale(savedLanguage == 'zh_tw' ? 'zh-tw' : savedLanguage)
   }

--- a/components/AlphaModal.tsx
+++ b/components/AlphaModal.tsx
@@ -11,6 +11,7 @@ import Checkbox from './Checkbox'
 import { useRouter } from 'next/router'
 import { LANGS } from './SettingsModal'
 import { RadioGroup } from '@headlessui/react'
+import dayjs from 'dayjs'
 
 export const ALPHA_MODAL_KEY = 'mangoAlphaAccepted-3.06'
 
@@ -34,7 +35,9 @@ const AlphaModal = ({
 
   const handleLanguageSelect = () => {
     setSavedLanguage(language)
+    document.cookie = `NEXT_LOCALE=${savedLanguage}; max-age=31536000; path=/`
     router.push({ pathname, query }, asPath, { locale: language })
+    dayjs.locale(savedLanguage == 'zh_tw' ? 'zh-tw' : savedLanguage)
   }
 
   const handleGetStarted = () => {

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -328,6 +328,7 @@ const LanguageSettings = () => {
   const { t } = useTranslation('common')
 
   const handleLangChange = () => {
+    document.cookie = `NEXT_LOCALE=${savedLanguage}; max-age=31536000; path=/`
     router.push({ pathname, query }, asPath, { locale: savedLanguage })
     dayjs.locale(savedLanguage == 'zh_tw' ? 'zh-tw' : savedLanguage)
   }


### PR DESCRIPTION
Set the NEXT_LOCALE cookie (https://nextjs.org/docs/advanced-features/i18n-routing#leveraging-the-next_locale-cookie) when the user chooses a language, to override locale detection based on the browser language.
