### PR TITLE
Handle margined deposit balances in SpotMax

### DIFF
--- a/components/trade_form/AdvancedTradeForm.tsx
+++ b/components/trade_form/AdvancedTradeForm.tsx
@@ -233,11 +233,22 @@ export default function AdvancedTradeForm({
         ).toNumber(),
         token.decimals
       )
+      
+      const depositBalance = mangoAccount
+        .getUiDeposit(
+          mangoCache.rootBankCache[tokenIndex],
+          mangoGroup,
+          tokenIndex
+        )
+        .toNumber()
 
       spotMax =
         side === 'buy'
           ? availableBalance / priceOrDefault.toNumber()
-          : availableBalance
+          : spotMargin
+            ? availableBalance
+            : depositBalance
+        }
     }
 
     const {


### PR DESCRIPTION
Problem: Spot sell - spotMax reflects availableBalance when using the percent buttons and margin unselected
Changes: Spot sell - spotMax reflects depositBalance when using the percent buttons and margin unselected

Image below (left: spotMax before change, right: spotMax after change, bottom: Balance)
![image](https://user-images.githubusercontent.com/47860274/183236627-7f1e0163-4d56-4258-b3a4-f005a8b1ce74.png)

In the above balance is 0.043109999, so it rounds to 0.0432 in balance, but 0.0431 is all that's available to sell at the 4 digit step size.