### PR TITLE
Add execution arrows to tradingview chart

### DIFF
--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -19,7 +19,6 @@ import { useTranslation } from 'next-i18next'
 import useLocalStorageState from '../hooks/useLocalStorageState'
 import { useWallet, Wallet } from '@solana/wallet-adapter-react'
 import dayjs from 'dayjs'
-import useInterval from 'hooks/useInterval'
 import usePrevious from 'hooks/usePrevious'
 
 export interface ChartContainerProps {

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'next-i18next'
 import useLocalStorageState from '../hooks/useLocalStorageState'
 import { useWallet, Wallet } from '@solana/wallet-adapter-react'
 import dayjs from 'dayjs'
+import useInterval from 'hooks/useInterval'
 
 export interface ChartContainerProps {
   container: ChartingLibraryWidgetOptions['container']
@@ -64,7 +65,8 @@ const TVChartContainer = () => {
   const selectedMarketName = selectedMarketConfig.name
   const tradeExecutions = useMangoStore((s) => s.tradingView.tradeExecutions)
   const tradeHistoryAndLiquidations = useMangoStore((s) => s.tradeHistory.parsed)
-  const tradeHistory = tradeHistoryAndLiquidations.filter((t) => !('liqor' in t))
+  const tradeHistory = tradeHistoryAndLiquidations.filter((t) => !('liqor' in t) && t.marketName === selectedMarketName && tradeExecutions.get(`${t.seqNum}${t.marketName}`) === undefined)
+  const mangoAccount = useMangoStore((s) => s.selectedMangoAccount.current)
 
   // @ts-ignore
   const defaultProps: ChartContainerProps = useMemo(
@@ -121,6 +123,7 @@ const TVChartContainer = () => {
             drawLinesForMarket(openOrders)
           }
           if (showTradeExecutions) {
+            deleteTradeExecutions()
             drawTradeExecutions()
           }
         }
@@ -747,9 +750,9 @@ const TVChartContainer = () => {
     const newTradeExecutions = new Map()
     if (tradeHistory?.length && chartReady && tvWidgetRef?.current) {
       tradeHistory 
-        .filter(trade => { //get trades in the current market that dont have an arrow drawn already
-          return trade.marketName === selectedMarketName && tradeExecutions.get(`${trade.seqNum}${trade.marketName}`) === undefined
-        })
+        // .filter(trade => { //get trades in the current market that dont have an arrow drawn already
+        //   return trade.marketName === selectedMarketName && tradeExecutions.get(`${trade.seqNum}${trade.marketName}`) === undefined
+        // })
         .slice(0, TRADE_EXECUTION_LIMIT)
         .forEach(trade => {
           const arrowID = tvWidgetRef.current?.chart()
@@ -767,14 +770,24 @@ const TVChartContainer = () => {
   }
 
   const deleteTradeExecutions = () => {
-    if (tradeHistory?.length && chartReady && tvWidgetRef?.current) {
-      for (const tradeExecution of tradeExecutions.values()) {
-        tradeExecution.remove()
-      }
+    const tradeExecutions = useMangoStore.getState().tradingView.tradeExecutions
+    if (tradeExecutions.size > 0) {
+      tradeExecutions?.forEach((value, key) => {
+        tradeExecutions.get(key)?.remove()
+      })
+      setMangoStore((state) => {
+        state.tradingView.tradeExecutions = new Map()
+      })
     }
-    setMangoStore(state => {
-      state.tradingView.tradeExecutions = new Map()
-    })
+
+    // if (tradeHistory?.length && chartReady && tvWidgetRef?.current) {
+    //   for (const tradeExecution of tradeExecutions.values()) {
+    //     tradeExecution.remove()
+    //   }
+    // }
+    // setMangoStore(state => {
+    //   state.tradingView.tradeExecutions = new Map()
+    // })
   }
 
   // delete trade executions if showTradeExecutions button is toggled
@@ -786,18 +799,41 @@ const TVChartContainer = () => {
 
   // update trade executions if transaction history changes
   useEffect(() => {
-    if (chartReady && tvWidgetRef?.current) {
-      const tradesInMarket = tradeHistory
-        .filter(trade => {
-          return trade.marketName === selectedMarketName
-        }).length
-      tvWidgetRef.current.onChartReady(() => {
-        if (tradeExecutions.size !== tradesInMarket && showTradeExecutions) {
+    if (chartReady && tvWidgetRef?.current && showTradeExecutions) {
+      sleep(2500).then(() => {
+        deleteTradeExecutions()
+        drawTradeExecutions()
+      })
+
+      // const tradesInMarket = tradeHistory
+      //   .filter(trade => {
+      //     return trade.marketName === selectedMarketName
+      //   }).length
+      // tvWidgetRef.current.onChartReady(() => {
+      //   if (tradeExecutions.size !== tradesInMarket && showTradeExecutions) {
+      //     deleteTradeExecutions()
+      //     drawTradeExecutions()
+      //   }
+      // })
+    }
+  }, [mangoAccount])
+
+  useEffect(() => {
+    // Just here to track how often trade history updates
+    console.log(mangoAccount?.publicKey + " tradeHistory updated")
+  }, [tradeHistory])
+
+  useInterval(() => {
+    if (chartReady && tvWidgetRef?.current && showTradeExecutions && tradeHistory) {
+      sleep(2500).then(() => {
+        console.log("useInterval Update - tradeHistory.length: " + tradeHistory.length)
+        if (tradeHistory) {
+          deleteTradeExecutions()
           drawTradeExecutions()
         }
       })
     }
-  }, [chartReady, tradeHistory])
+  }, 10000)
   
 
   return (

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -717,7 +717,6 @@ const TVChartContainer = () => {
           return trade.marketName === selectedMarketName
         }).length
       tvWidgetRef.current.onChartReady(() => {
-        console.log(`tradeArrows.size: ${tradeArrows.size}; tradesInMarket: ${tradesInMarket}`)
         if (tradeArrows.size !== tradesInMarket) {
           drawTradeExecutions()
         }

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -767,12 +767,6 @@ const TVChartContainer = () => {
   }
 
   const deleteTradeExecutions = () => {
-    if(previousTradeExecutions && chartReady && tvWidgetRef?.current) {
-      console.log(`previous trade executions: ${JSON.stringify(previousTradeExecutions.values())}`)
-      for (const tradeExecution of previousTradeExecutions.values()) {
-        tradeExecution.remove()
-      }
-    }
     if (tradeHistory?.length && chartReady && tvWidgetRef?.current) {
       for (const tradeExecution of tradeExecutions.values()) {
         tradeExecution.remove()
@@ -788,7 +782,7 @@ const TVChartContainer = () => {
     if (!showTradeExecutions) {
       deleteTradeExecutions()
     }
-  }, [showTradeExecutions, mangoAccount])
+  }, [showTradeExecutions])
 
   // update trade executions if transaction history changes
   useEffect(() => {

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -54,6 +54,8 @@ const TVChartContainer = () => {
   const isMobile = width ? width < breakpoints.sm : false
   const mangoClient = useMangoStore.getState().connection.client
   const selectedMarketName = selectedMarketConfig.name
+  const tradeHistoryAndLiquidations = useMangoStore((s) => s.tradeHistory.parsed)
+  const tradeHistory = tradeHistoryAndLiquidations.filter((t) => !('liqor' in t))
 
   // @ts-ignore
   const defaultProps: ChartContainerProps = useMemo(
@@ -581,6 +583,27 @@ const TVChartContainer = () => {
     }
   }
 
+  const drawTradeArrows = () => {
+    const tradeArrows = useMangoStore.getState().tradingView.tradeArrows
+    const newTradeArrows = new Map()
+    if (tradeHistory?.length && chartReady && tvWidgetRef?.current) {
+      console.log(`selectedMarketName: ${selectedMarketName}`)
+      // console.log(`tradeHistory 1-20: ${JSON.stringify(tradeHistory.slice(0,20))}`)
+      tradeHistory
+        .filter(trade => {
+          return trade.marketName === selectedMarketName && tradeArrows.get(`${trade.seqNum}${trade.marketName}`) === undefined
+        })
+        .forEach(trade => {
+          const arrowID = tvWidgetRef.current?.chart().createShape({time: trade.loadTimestamp, price: trade.price}, {shape: trade.side === "buy" ? "arrow_up" : "arrow_down"})
+          console.log(`Drawing ${trade.side} arrow at time: ${trade.loadTimestamp}, Price: ${trade.price}`)
+          newTradeArrows.set(`${trade.seqNum}${trade.marketName}`, arrowID)
+      })
+    }
+    setMangoStore((state) => {
+      state.tradingView.tradeArrows = newTradeArrows
+    })
+  }
+
   const drawLinesForMarket = (openOrders) => {
     const newOrderLines = new Map()
     if (openOrders?.length) {
@@ -617,6 +640,7 @@ const TVChartContainer = () => {
     }
   }, [showOrderLines])
 
+  
   // updated order lines if a user's open orders change
   useEffect(() => {
     let subscription
@@ -659,6 +683,24 @@ const TVChartContainer = () => {
     }
     return subscription
   }, [chartReady, showOrderLines, selectedMarketName])
+
+  // update trade orders if transaction history changes
+  useEffect(() => {
+    if (chartReady && tvWidgetRef?.current) {
+      const tradeArrows = useMangoStore.getState().tradingView.tradeArrows
+      const tradesInMarket = tradeHistory
+        .filter(trade => {
+          return trade.marketName === selectedMarketName
+        }).length
+      tvWidgetRef.current.onChartReady(() => {
+        if (tradeArrows.size !== tradesInMarket) {
+          drawTradeArrows()
+        }
+      })
+      // tvWidgetRef.current?.chart().createShape({time: 1661844174, price: 32.00}, {shape: "arrow_up"})
+      // tvWidgetRef.current?.chart().createShape({time: 1661844174, price: 30.00}, {shape: "arrow_up"})
+    }
+  }, [chartReady, tradeHistory])
 
   return (
     <div id={defaultProps.container as string} className="tradingview-chart" />

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -641,7 +641,6 @@ const TVChartContainer = () => {
     }
   }, [showOrderLines])
 
-  
   // updated order lines if a user's open orders change
   useEffect(() => {
     let subscription

--- a/components/TVChartContainer.tsx
+++ b/components/TVChartContainer.tsx
@@ -783,7 +783,14 @@ const TVChartContainer = () => {
     })
   }
 
-  // update trade orders if transaction history changes
+  // delete trade executions if showTradeExecutions button is toggled
+  useEffect(() => {
+    if (!showTradeExecutions) {
+      deleteTradeExecutions()
+    }
+  }, [showTradeExecutions, mangoAccount])
+
+  // update trade executions if transaction history changes
   useEffect(() => {
     if (chartReady && tvWidgetRef?.current) {
       const tradesInMarket = tradeHistory

--- a/public/locales/en/tv-chart.json
+++ b/public/locales/en/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "Order Price Outside Range",
   "slippage-accept": "Please use the trade input form if you wish to accept the potential slippage.",
   "slippage-warning": "Your order price ({{updatedOrderPrice}}) is greater than 5% {{aboveBelow}} the current market price ({{selectedMarketPrice}}) indicating you might incur significant slippage.",
-  "toggle-order-line": "Toggle order line visibility"
+  "toggle-order-line": "Toggle order line visibility",
+  "toggle-trade-executions": "Toggle trade execution visibility"
 }

--- a/public/locales/es/tv-chart.json
+++ b/public/locales/es/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "Order Price Outside Range",
   "slippage-accept": "Please use the trade input form if you wish to accept the potential slippage.",
   "slippage-warning": "Your order price ({{updatedOrderPrice}}) is greater than 5% {{aboveBelow}} the current market price ({{selectedMarketPrice}}) indicating you might incur significant slippage.",
-  "toggle-order-line": "Toggle order line visibility"
+  "toggle-order-line": "Toggle order line visibility",
+  "toggle-trade-executions": "Toggle trade execution visibility"
 }

--- a/public/locales/kr/tv-chart.json
+++ b/public/locales/kr/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "Order Price Outside Range",
   "slippage-accept": "Please use the trade input form if you wish to accept the potential slippage.",
   "slippage-warning": "Your order price ({{updatedOrderPrice}}) is greater than 5% {{aboveBelow}} the current market price ({{selectedMarketPrice}}) indicating you might incur significant slippage.",
-  "toggle-order-line": "Toggle order line visibility"
+  "toggle-order-line": "Toggle order line visibility",
+  "toggle-trade-executions": "Toggle trade execution visibility"
 }

--- a/public/locales/ru/tv-chart.json
+++ b/public/locales/ru/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "Цена ордера вне диапазона",
   "slippage-accept": "Пожалуйста, используйте форму ввода сделки, если вы хотите принять потенциальное проскальзывание.",
   "slippage-warning": "Цена вашего ордера ({{updatedOrderPrice}}) превышает 5% {{aboveBelow}} от текущей рыночной цены ({{selectedMarketPrice}}) что указывает на то, что вы можете понести значительное проскальзывание.",
-  "toggle-order-line": "Переключить видимость строки ордера"
+  "toggle-order-line": "Переключить видимость строки ордера",
+  "toggle-trade-executions": "Toggle trade execution visibility"
 }

--- a/public/locales/zh/tv-chart.json
+++ b/public/locales/zh/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "订单价格在范围之外",
   "slippage-accept": "若您接受潜在的下滑请使用交易表格进行。",
   "slippage-warning": "您的订单价格({{updatedOrderPrice}})多余5%{{aboveBelow}}市场价格({{selectedMarketPrice}})表是您也许遭受可观的下滑。",
-  "toggle-order-line": "切换订单线可见性"
+  "toggle-order-line": "切换订单线可见性",
+  "toggle-trade-executions": "切换成交可见性"
 }

--- a/public/locales/zh_tw/tv-chart.json
+++ b/public/locales/zh_tw/tv-chart.json
@@ -9,5 +9,6 @@
   "outside-range": "訂單價格在範圍之外",
   "slippage-accept": "若您接受潛在的下滑請使用交易表格進行。",
   "slippage-warning": "您的訂單價格({{updatedOrderPrice}})多餘5%{{aboveBelow}}市場價格({{selectedMarketPrice}})表是您也許遭受可觀的下滑。",
-  "toggle-order-line": "切換訂單線可見性"
+  "toggle-order-line": "切換訂單線可見性",
+  "toggle-trade-executions": "切換成交可見性"
 }

--- a/stores/useMangoStore.tsx
+++ b/stores/useMangoStore.tsx
@@ -335,7 +335,7 @@ export type MangoStore = {
   marketsInfo: any[]
   tradingView: {
     orderLines: Map<string, IOrderLineAdapter>
-    tradeArrows: Map<string, IExecutionLineAdapter>
+    tradeExecutions: Map<string, IExecutionLineAdapter>
   }
   coingeckoPrices: { data: any[]; loading: boolean }
 }
@@ -466,7 +466,7 @@ const useMangoStore = create<
       },
       tradingView: {
         orderLines: new Map(),
-        tradeArrows: new Map(),
+        tradeExecutions: new Map(),
       },
       coingeckoPrices: { data: [], loading: false },
       profile: {

--- a/stores/useMangoStore.tsx
+++ b/stores/useMangoStore.tsx
@@ -40,7 +40,7 @@ import {
 } from '../components/SettingsModal'
 import { MSRM_DECIMALS } from '@project-serum/serum/lib/token-instructions'
 import { decodeBook } from '../hooks/useHydrateStore'
-import { IOrderLineAdapter } from '../public/charting_library/charting_library'
+import { EntityId, IOrderLineAdapter } from '../public/charting_library/charting_library'
 import { Wallet } from '@solana/wallet-adapter-react'
 import { coingeckoIds, fetchNftsFromHolaplexIndexer } from 'utils/tokens'
 import { sign } from 'tweetnacl'
@@ -335,6 +335,7 @@ export type MangoStore = {
   marketsInfo: any[]
   tradingView: {
     orderLines: Map<string, IOrderLineAdapter>
+    tradeArrows: Map<string, EntityId>
   }
   coingeckoPrices: { data: any[]; loading: boolean }
 }
@@ -465,6 +466,7 @@ const useMangoStore = create<
       },
       tradingView: {
         orderLines: new Map(),
+        tradeArrows: new Map(),
       },
       coingeckoPrices: { data: [], loading: false },
       profile: {

--- a/stores/useMangoStore.tsx
+++ b/stores/useMangoStore.tsx
@@ -40,7 +40,7 @@ import {
 } from '../components/SettingsModal'
 import { MSRM_DECIMALS } from '@project-serum/serum/lib/token-instructions'
 import { decodeBook } from '../hooks/useHydrateStore'
-import { EntityId, IOrderLineAdapter } from '../public/charting_library/charting_library'
+import { IExecutionLineAdapter, IOrderLineAdapter } from '../public/charting_library/charting_library'
 import { Wallet } from '@solana/wallet-adapter-react'
 import { coingeckoIds, fetchNftsFromHolaplexIndexer } from 'utils/tokens'
 import { sign } from 'tweetnacl'
@@ -335,7 +335,7 @@ export type MangoStore = {
   marketsInfo: any[]
   tradingView: {
     orderLines: Map<string, IOrderLineAdapter>
-    tradeArrows: Map<string, EntityId>
+    tradeArrows: Map<string, IExecutionLineAdapter>
   }
   coingeckoPrices: { data: any[]; loading: boolean }
 }


### PR DESCRIPTION
Per [this comment](https://discord.com/channels/791995070613159966/833812133316657183/1013577729003753534) in Discord, I've added FTX style execution arrows to the tradingview chart. It currently draws an arrow for every trade in the current market in the accounts trade history. I have not tested it on an account with hundreds or thousands of trades. Hopefully someone with an account like that can try it out.

PR Requirements:

- [x] Summarize changes
- [x] Included a screenshot, if applicable
- [x] Test on mobile
- [x] Request at least one reviewer

![image](https://user-images.githubusercontent.com/4095852/187453921-b1a2c616-9642-48e9-82c8-45f4db25f0a2.png)
